### PR TITLE
docs: add GitHub Pages site and trim README for v0.4.1

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,46 @@
+name: Deploy Docs to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Build and Deploy
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Configure Pages
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
+        with:
+          path: docs
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-06-12
+
+Adds a GitHub Pages documentation site so consumers and maintainers get a navigable how-to reference instead of one large README, and trims the README to a short landing page that links to it.
+
+### Added
+
+- Documentation site under `docs/`: a custom static site (landing page plus Getting Started, Usage, Maintaining, and Troubleshooting pages) with a shared dark theme in `docs/assets/style.css` and a `docs/.nojekyll` marker.
+- GitHub Pages deploy workflow (`.github/workflows/docs.yml`): publishes `docs/` via GitHub Actions on every push to `main` that touches `docs/`, with SHA-pinned actions, least-privilege permissions, and `persist-credentials: false`.
+
+### Changed
+
+- README trimmed to a short landing page that links to the documentation site and retains quick start, repository structure, and versioning.
+
+### Consumer install
+
+Pin to this version:
+
+```powershell
+apm install "Peter-N91/hve-squad#v0.4.1"
+```
+
+[0.4.1]: https://github.com/Peter-N91/hve-squad/releases/tag/v0.4.1
+
 ## [0.4.0] - 2026-06-12
 
 Adds two new autonomy modes — a full `mode=autopilot` pipeline and a remote, phone-approvable notification channel — so the squad can run unattended (for example, a multi-hour job on a VM) and stop for a human only at impactful actions and final-outcome validation.

--- a/README.md
+++ b/README.md
@@ -1,26 +1,39 @@
 # hve-squad
 
-APM package that assembles HVE Core agents, prompts, instructions, and skills into one installable bundle for Copilot target environments.
+APM package that assembles HVE Core agents, prompts, instructions, and skills into one
+installable bundle for Copilot target environments, and ships a Squad Coordinator that routes
+your request to a cast of agents in parallel.
 
-## What this project does
+## Documentation
 
-This repository provides a curated APM package that references content from `microsoft/hve-core` under:
+Full documentation lives on the project site:
 
-- `.github/agents`
-- `.github/instructions`
-- `.github/prompts`
-- `.github/skills`
+**[peter-n91.github.io/hve-squad](https://peter-n91.github.io/hve-squad/)**
 
-Instead of manually maintaining hundreds of dependency paths, this project uses an automation script to regenerate the dependency list in `apm.yml`.
+| Page                                                                          | What it covers                                                           |
+|-------------------------------------------------------------------------------|--------------------------------------------------------------------------|
+| [Getting Started](https://peter-n91.github.io/hve-squad/getting-started.html) | Prerequisites, installing the package with the correct target, first run |
+| [Usage](https://peter-n91.github.io/hve-squad/usage.html)                     | Profiles, autonomy modes, remote approval, and first-run Init Mode       |
+| [Maintaining](https://peter-n91.github.io/hve-squad/maintaining.html)         | Dependency generation, author workflow, customization, release process   |
+| [Troubleshooting](https://peter-n91.github.io/hve-squad/troubleshooting.html) | Known install errors with fixes, versioning, and repository notes        |
 
-## Why this exists
+The site source is in [docs/](docs/) and is published to GitHub Pages by
+[.github/workflows/docs.yml](.github/workflows/docs.yml) on every push to `main` that touches
+`docs/`.
 
-Maintaining explicit APM dependency links by hand is error-prone because HVE Core evolves frequently.
-This package solves that by:
+## Quick start
 
-- Auto-discovering all supported markdown artifacts from selected HVE Core folders
-- Updating `dependencies.apm` in `apm.yml`
-- Providing a repeatable author workflow before lock/pack/publish
+Install the package into the project you want the squad in, then invoke `/squad` in Copilot Chat:
+
+```powershell
+apm install "Peter-N91/hve-squad#v0.4.1" --target copilot
+```
+
+```text
+/squad request="add input validation to the login form"
+```
+
+See [Getting Started](https://peter-n91.github.io/hve-squad/getting-started.html) for the full flow.
 
 ## Repository structure
 
@@ -28,365 +41,12 @@ This package solves that by:
 - `apm.lock.yaml`: resolved dependency lock file
 - `scripts/Update-ApmDependencies.ps1`: dependency generator
 - `squad-src/.github/`: locally authored squad source (agents, prompts, instructions, skills)
+- `docs/`: documentation site published to GitHub Pages
 - `apm_modules/`: installed dependencies (ignored by git)
-- `.github/`: generated/deployed local assets (ignored by git, except `.github/workflows/` if tracked)
-
-## Prerequisites
-
-- PowerShell 7+
-- Git
-- APM CLI installed and available in `PATH`
-- Access to `microsoft/hve-core` repository
-
-## Scripts
-
-Defined in `apm.yml`:
-
-- `sync-deps`
-  - Regenerates `dependencies.apm` from HVE Core content.
-- `install-sync`
-  - Regenerates `dependencies.apm` and runs `apm install`.
-
-## Maintainer workflow (author of this package)
-
-1. Regenerate dependencies:
-
-   ```powershell
-   apm run sync-deps
-   ```
-
-2. Install dependencies locally:
-
-   ```powershell
-   apm install
-   ```
-
-   Or:
-
-   ```powershell
-   apm run install-sync
-   ```
-
-3. Refresh lockfile:
-
-   ```powershell
-   apm lock
-   ```
-
-4. [OPTIONAL] Build package artifact (only needed to build a plugin):
-
-   ```powershell
-   apm pack
-   ```
-
-5. [OPTIONAL] Publish (if applicable):
-
-   ```powershell
-   apm publish
-   ```
-
-Recommended sequence before release:
-
-1. `apm run sync-deps`
-2. `apm lock`
-3. `apm pack` (optional)
-
-## Consumer workflow (GitHub installs for your package)
-
-This is everything a consumer needs to install the package, run the squad, and rebuild
-their deployed assets.
-
-### 1. Install the package
-
-Run `apm install` from the root of the project you want the squad in.
-
-> **Heads-up (APM 0.18.0+).** APM no longer silently defaults to the Copilot harness. In
-> a project with no existing `.github/agents/`, `.github/prompts/`, `.github/instructions/`,
-> `.claude/`, `.cursor/`, etc., `apm install` will fail with `[x] No harness detected`
-> *after* downloading sources into `apm_modules/` but *before* deploying anything into
-> `.github/`. You must tell APM which harness to deploy to using one of the options below.
-
-**Option A — pass `--target copilot` on every install (one-off):**
-
-```powershell
-apm install "Peter-N91/hve-squad#vX.Y.z" --target copilot  # pinned (recommended)
-# or
-apm install Peter-N91/hve-squad --target copilot           # latest on default branch
-```
-
-**Option B — declare the target once in your project's `apm.yml` (persistent, recommended):**
-
-Create an `apm.yml` at the root of your consumer project:
-
-```yaml
-name: my-project
-version: 0.1.0
-targets:
-  - copilot
-```
-
-Then `apm install "Peter-N91/hve-squad#vX.Y.z"` (no flag needed) will deploy to
-Copilot from now on. This also makes future `apm install` / `apm update` runs reproducible.
-
-Either way, this deploys the bundled HVE Core agents, prompts, instructions, and skills —
-plus the squad — into your project's `.github/` tree. Consumers do **not** need
-`sync-deps` or `install-sync`; those are maintainer-only scripts for regenerating the
-dependency list.
-
-**If your first install already failed with `No harness detected`:** the sources are
-already in `apm_modules/`. Just re-run with `--target copilot` (Option A) or add the
-`targets:` block to `apm.yml` (Option B) and re-run `apm install`; APM will re-run the
-deploy step and populate `.github/`.
-
-### 2. Run the squad
-
-The squad is a user-invocable Squad Coordinator that routes your request to a cast of
-HVE Core agents and persists its state under `.copilot-tracking/squad/`. Invoke it with
-the `/squad` prompt in Copilot Chat:
-
-```text
-/squad request="add input validation to the login form"
-```
-
-Optional inputs:
-
-- `profile=default|full|security|design|architecture` — seeds which cast is created on
-  first run. If omitted on a fresh project, the coordinator inspects your repo and
-  proposes a recommended profile before creating anything.
-- `tier=fast|default` — a per-turn model-tier hint that overrides the coordinator's
-  cost-first defaults.
-- `mode=autonomous|autopilot` — the autonomy mode for this turn (see **Autonomy modes**
-  below). Omit it to run interactively, approving each step.
-
-```text
-/squad request="threat-model the auth service" profile=security
-/squad request="summarize the data layer" tier=fast
-/squad request="build the booking service end to end" mode=autopilot
-```
-
-**Autonomy modes** (how much the squad does before it asks you):
-
-| Mode                  | How to run it       | Who approves what                                                                                          |
-|-----------------------|---------------------|------------------------------------------------------------------------------------------------------------|
-| Interactive (default) | no `mode` flag      | You approve **each step** (research, plan, implement, review). A ping fires at every step gate.            |
-| `mode=autonomous`     | `mode=autonomous`   | A narrow validator loop: the council re-validates one implementer output (max 2 cycles), then returns.     |
-| `mode=autopilot`      | `mode=autopilot`    | The squad runs research → plan → implement → review on its own and asks you **only** for impactful actions (deploy, `git push`, merge, schema/data changes) and to validate the **final outcome**. |
-
-Autopilot is the "tell it once, let it run" mode: it sequences the whole pipeline
-autonomously but always stops for a human before anything irreversible and before release.
-The two impactful/final stop-points fire a notification through the **approval channel** you
-choose at build time (interactive mode pings you at every step instead).
-
-**Approving remotely (unattended / VM runs).** If you run the squad on a VM for a long job,
-pick the `github-issue` approval channel at build time. At each gate the squad opens a
-GitHub issue, assigns and @mentions you (so you get a GitHub mobile push), and waits. You
-approve from your phone with a comment — `/approve`, `/approve-all`, `/changes: <note>`, or
-`/stop` — or a `squad/*` label, without touching the VM. Only your registered handle (or a
-repo collaborator) can approve, and only those keywords act. The other channels are
-`webhook` (an outbound Teams/Slack/Discord ping only) and `in-chat` (the default, which
-needs you at the PC). No channel requires the package to ship an email or chat transport —
-when a channel's tooling is absent it degrades to an in-chat approval, and the squad never
-proceeds on a timeout.
-
-**Remote approval setup (one-time, only for `github-issue`).** Local and in-chat runs need
-nothing extra. To approve remotely from a VM run, set up the `github-issue` channel once:
-
-1. **Authenticate GitHub on the run host.** Either run `gh auth login` (the `gh` CLI is
-   sufficient on a headless VM) or configure the official `github` MCP server. The package
-   ships a reference entry for it in `.github/skills/squad/mcp.template.json` that you can
-   merge into your `.vscode/mcp.json`; the GitHub MCP is preferred when present, and the
-   squad falls back to `gh`, then to in-chat. The token needs `repo` + `issues` scope.
-2. **Install the approval watcher.** Copy the reference workflow
-   `.github/skills/squad/github-approval-watcher.workflow.yml` to
-   `.github/workflows/squad-approval-watcher.yml` in the repo that hosts your approval
-   issues, then commit it. It relays your `/approve`, `/approve-all`, `/changes:`, or
-   `/stop` reply back so the run resumes — and only an authorized handle's recognized
-   keyword acts (free-form comment text is never executed as a command).
-3. **Pick `github-issue` at build time** and give the coordinator the GitHub handle to
-   @mention and the `owner/repo` for approval issues (defaults to the current repo).
-
-**First run (Init Mode).** When a project has no `.copilot-tracking/squad/team.md`, the
-coordinator proposes a squad profile, waits for your confirmation, asks for an optional
-approval channel (`github-issue` for remote/phone approval, `webhook`, or `in-chat`), then
-seeds `team.md`, `routing.md`, `decisions.md`, `notifications.md`, `state.json`, and a
-`history/` directory. It never writes files before you confirm. After that, each `/squad`
-call routes against the seeded roster.
-
-**Profiles** (the cast each one seeds):
-
-| Profile        | Members                                            | Use when                                          |
-|----------------|----------------------------------------------------|---------------------------------------------------|
-| `default`      | lead, researcher, developer, tester, scribe        | General-purpose work; recommended starting point  |
-| `full`         | all 10 deployed roles                              | Complex, cross-cutting projects                   |
-| `security`     | security, rai, fact-checker, researcher, scribe    | Security, threat-modeling, responsible-AI focus   |
-| `design`       | designer, researcher, lead, tester, scribe         | UX/UI and product-design focus                    |
-| `architecture` | architect, researcher, lead, developer, scribe     | System design and architecture focus              |
-
-Requirements for running the squad:
-
-- A `runSubagent` or `task` tool must be enabled so the coordinator can dispatch the
-  cast.
-- The memory tool should be available for durable per-agent notes under `/memories/repo/`.
-- For the `github-issue` approval channel only: an authenticated `gh` CLI or `github` MCP
-  on the run host, and the approval-watcher workflow installed (see *Remote approval
-  setup* above). Interactive and in-chat runs need neither.
-
-You can re-cast the squad later by editing `.copilot-tracking/squad/team.md` or asking the
-coordinator to switch profiles.
-
-### 3. Rebuild (re-deploy) after updating
-
-To pull a newer version of the package or refresh your deployed assets, re-run install
-with the version tag you want (include `--target copilot` if you have not declared
-`targets:` in your project's `apm.yml`):
-
-```powershell
-apm install "Peter-N91/hve-squad#vX.Y.z" --target copilot
-```
-
-`apm install` re-flattens the package into `.github/`. Your squad **state** under
-`.copilot-tracking/squad/` is created per-project and is never packaged, so re-installing
-does not overwrite your roster, routing, decisions, or history.
-
-## How dependency generation works
-
-The generator script:
-
-- Connects to `microsoft/hve-core` at a target ref (default: `main`)
-- Enumerates files under:
-  - `.github/agents`
-  - `.github/instructions`
-  - `.github/prompts`
-  - `.github/skills`
-- Filters for markdown artifacts
-- Rewrites only `dependencies.apm` in `apm.yml`
-
-This keeps package metadata stable while updating the dependency list safely.
-
-## Squad source
-
-In addition to the `microsoft/hve-core` dependencies, this package ships a locally authored
-"squad" — a Squad Coordinator plus supporting agents, instructions, a prompt, and a skill.
-The squad source lives under:
-
-- `squad-src/.github/agents/squad/`
-- `squad-src/.github/instructions/squad/`
-- `squad-src/.github/prompts/squad/`
-- `squad-src/.github/skills/squad/`
-
-### Why the source is separate from the deployed `.github/` tree
-
-`apm install` deploys agents and prompts *flattened* into the consumer's `.github/` tree. If the
-squad source lived directly under the top-level `.github/agents/` (or `.github/prompts/`), a later
-`apm install` would clobber it. Keeping the authored source under `squad-src/.github/...` places it
-outside the deploy flatten zone while preserving the `.github/{agents,prompts,instructions,skills}/`
-prefix the deploy mapping expects. Runtime squad *state* is created per-project under
-`.copilot-tracking/squad/` and is never packaged.
-
-### How squad entries are generated
-
-`Update-ApmDependencies.ps1` enumerates the squad source from the *local* filesystem (it is not
-cloned, because the source lives in this working tree and may not be pushed yet). Squad entries are
-emitted as remote virtual paths of the form
-`<SquadRepoSlug>/<SquadSourceRoot>/.github/...`, for example
-`Peter-N91/hve-squad/squad-src/.github/agents/squad/squad-coordinator.agent.md`. They are appended
-after the hve-core entries in `dependencies.apm`.
-
-The sync command accepts two squad-specific parameters:
-
-```powershell
-pwsh -File scripts/Update-ApmDependencies.ps1 `
-  -SquadSourceRoot squad-src `
-  -SquadRepoSlug Peter-N91/hve-squad
-```
-
-- `SquadSourceRoot`: local path to the squad source tree (default: `squad-src`). If the path does
-  not exist, squad enumeration is skipped without error.
-- `SquadRepoSlug`: `owner/repo` that hosts the squad source (default: `Peter-N91/hve-squad`).
-
-Use `-DryRun` to preview both the hve-core and squad entries without writing `apm.yml`.
-
-> Note: `apm lock` and `apm install` can only resolve the squad virtual paths once the
-> `squad-src/` tree has been pushed to the `SquadRepoSlug` remote. Until then, `apm.yml` lists the
-> squad entries but `apm.lock.yaml` will not record them.
-
-## Customization
-
-You can tune generation behavior in `scripts/Update-ApmDependencies.ps1`:
-
-- `RepoSlug`: source repository
-- `Ref`: branch/tag/commit to scan
-- `IncludeRoots`: folders included in discovery
-- `IncludeRegex`: file filter pattern
-- `SquadSourceRoot`: local squad source tree path
-- `SquadRepoSlug`: `owner/repo` hosting the squad source
-
-## Troubleshooting
-
-- `[x] No harness detected` after `apm install` (APM 0.18.0+):
-  - APM downloaded the sources into `apm_modules/` but skipped the deploy step because
-    no harness marker was found in your project (no `.github/agents/`, `.github/prompts/`,
-    `.claude/`, `.cursor/`, etc.). Re-run with `--target copilot`:
-
-    ```powershell
-    apm install "Peter-N91/hve-squad#vX.Y.z" --target copilot
-    ```
-
-    Or add a `targets:` block to your project's `apm.yml` so future installs work without
-    the flag (see *Consumer workflow \u2192 Install the package, Option B*).
-- `apm_modules/` populated but `.github/` is empty and no error visible:
-  - Same root cause as above \u2014 scroll up in your terminal for the `No harness detected`
-    message and apply the `--target copilot` fix.
-- No scripts found:
-  - Check the `scripts` block in `apm.yml` and run `apm list`.
-- Access failures to HVE Core:
-  - Confirm git authentication and repository visibility.
-- Dependencies look stale:
-  - Run `apm run sync-deps`, then `apm lock`.
-- `.github` still appears in git status after ignoring:
-  - Run `git rm -r --cached .github` once, then `git add .github/workflows` (if you track workflows here), then commit.
+- `.github/`: generated/deployed local assets (ignored by git, except `.github/workflows/`)
 
 ## Versioning
 
 - Releases follow [Semantic Versioning](https://semver.org/).
 - See [CHANGELOG.md](CHANGELOG.md) for what is included in each version.
 - Consumers can pin to a tagged version, for example `apm install "Peter-N91/hve-squad#vX.Y.z"`.
-
-## Release process
-
-Releases use a tag-based flow on top of the default branch (`main`). The tag is the
-release artifact consumers install with `apm install "Peter-N91/hve-squad#vX.Y.Z"`.
-
-1. Cut a release branch from `main`:
-
-   ```powershell
-   git checkout main
-   git pull
-   git checkout -b release/vX.Y.Z
-   ```
-
-2. Update version metadata:
-   - Bump `version:` in `apm.yml` to `X.Y.Z`.
-   - Add a `## [X.Y.Z]` section to [CHANGELOG.md](CHANGELOG.md) describing the changes.
-   - Refresh the lockfile if dependencies changed: `apm run sync-deps` then `apm lock`.
-
-3. Open a PR into `main` titled `release: vX.Y.Z` (the PR template fills in the checklist).
-
-4. After the PR is merged, tag the merge commit on `main` and push the tag:
-
-   ```powershell
-   git checkout main
-   git pull
-   git tag -a vX.Y.Z -m "Release vX.Y.Z"
-   git push origin vX.Y.Z
-   ```
-
-5. (Optional) Publish a GitHub Release for the tag.
-
-Avoid a long-lived `release` branch. Only create `release/vX.Y.z` from an existing
-tag when you need to patch an older version after newer work has landed on `main`.
-
-## Notes
-
-- `.gitignore` ignores `apm_modules/`, generated `.github` assets, and keeps `.github/workflows/` tracked.
-- The package remains reproducible through `apm.lock.yaml`.

--- a/apm.yml
+++ b/apm.yml
@@ -1,5 +1,5 @@
 name: hve-squad
-version: 0.4.0
+version: 0.4.1
 description: APM package for hve-core and squad together
 author: Peter-N91
 # Which agent platforms to deploy to.

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -1,0 +1,274 @@
+/* hve-squad docs — dark, terminal-inspired theme */
+
+:root {
+  --bg: #0b0f14;
+  --bg-soft: #11171f;
+  --panel: #151c26;
+  --panel-2: #1b2430;
+  --border: #243140;
+  --text: #d7e0ea;
+  --muted: #8a98a8;
+  --accent: #3ddc97;
+  --accent-2: #5aa9ff;
+  --warn: #ffc857;
+  --danger: #ff6b6b;
+  --code-bg: #0e141b;
+  --radius: 12px;
+  --maxw: 980px;
+  --mono: "SFMono-Regular", "JetBrains Mono", "Fira Code", Consolas, "Liberation Mono", monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+}
+
+* { box-sizing: border-box; }
+
+html { scroll-behavior: smooth; }
+
+body {
+  margin: 0;
+  background:
+    radial-gradient(1200px 600px at 80% -10%, rgba(90, 169, 255, 0.08), transparent 60%),
+    radial-gradient(900px 500px at -10% 10%, rgba(61, 220, 151, 0.07), transparent 55%),
+    var(--bg);
+  color: var(--text);
+  font-family: var(--sans);
+  line-height: 1.65;
+  font-size: 16px;
+  -webkit-font-smoothing: antialiased;
+}
+
+a { color: var(--accent-2); text-decoration: none; }
+a:hover { text-decoration: underline; }
+
+.container {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 0 20px;
+}
+
+/* Top navigation */
+.nav {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: blur(8px);
+  background: rgba(11, 15, 20, 0.82);
+  border-bottom: 1px solid var(--border);
+}
+.nav-inner {
+  max-width: var(--maxw);
+  margin: 0 auto;
+  padding: 12px 20px;
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  flex-wrap: wrap;
+}
+.brand {
+  font-family: var(--mono);
+  font-weight: 700;
+  color: var(--text);
+  letter-spacing: 0.5px;
+}
+.brand .dot { color: var(--accent); }
+.nav-links {
+  display: flex;
+  gap: 16px;
+  margin-left: auto;
+  flex-wrap: wrap;
+}
+.nav-links a {
+  color: var(--muted);
+  font-size: 14px;
+  padding: 4px 2px;
+}
+.nav-links a:hover,
+.nav-links a.active { color: var(--text); text-decoration: none; }
+.nav-links a.active { border-bottom: 2px solid var(--accent); }
+
+/* Hero */
+.hero {
+  padding: 64px 0 40px;
+  border-bottom: 1px solid var(--border);
+}
+.eyebrow {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: 14px;
+}
+.hero h1 {
+  font-size: clamp(28px, 5vw, 44px);
+  line-height: 1.15;
+  margin: 0 0 16px;
+}
+.hero p.lead {
+  font-size: 18px;
+  color: var(--muted);
+  max-width: 720px;
+  margin: 0 0 24px;
+}
+
+/* Buttons */
+.btn {
+  display: inline-block;
+  padding: 10px 18px;
+  border-radius: 10px;
+  font-weight: 600;
+  font-size: 15px;
+  border: 1px solid var(--border);
+  margin: 4px 8px 4px 0;
+}
+.btn:hover { text-decoration: none; }
+.btn-primary {
+  background: var(--accent);
+  color: #06281c;
+  border-color: var(--accent);
+}
+.btn-primary:hover { filter: brightness(1.08); }
+.btn-ghost { background: var(--panel); color: var(--text); }
+.btn-ghost:hover { background: var(--panel-2); }
+
+/* Section labels */
+.section { padding: 44px 0; }
+.section-label {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin: 0 0 20px;
+}
+
+/* Card grid */
+.grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 16px;
+}
+.card {
+  display: block;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 20px;
+  transition: transform 0.12s ease, border-color 0.12s ease, background 0.12s ease;
+}
+.card:hover {
+  text-decoration: none;
+  transform: translateY(-2px);
+  border-color: var(--accent);
+  background: var(--panel-2);
+}
+.card .icon { font-size: 22px; }
+.card h3 { margin: 10px 0 6px; font-size: 17px; color: var(--text); }
+.card p { margin: 0; color: var(--muted); font-size: 14px; }
+.card .tag {
+  display: inline-block;
+  margin-top: 12px;
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 1px;
+  color: var(--accent);
+  text-transform: uppercase;
+}
+
+/* Content typography */
+.content { padding: 40px 0 80px; }
+.content h2 {
+  font-size: 26px;
+  margin: 40px 0 12px;
+  padding-top: 8px;
+  border-top: 1px solid var(--border);
+}
+.content h2:first-of-type { border-top: none; }
+.content h3 { font-size: 19px; margin: 26px 0 8px; }
+.content p, .content li { color: var(--text); }
+.content ul, .content ol { padding-left: 22px; }
+.content li { margin: 6px 0; }
+
+/* Code */
+code {
+  font-family: var(--mono);
+  font-size: 13.5px;
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1px 6px;
+  color: #e6edf3;
+}
+pre {
+  background: var(--code-bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 16px;
+  overflow-x: auto;
+  line-height: 1.5;
+}
+pre code {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 13.5px;
+}
+
+/* Tables */
+table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 16px 0;
+  font-size: 14px;
+}
+th, td {
+  border: 1px solid var(--border);
+  padding: 9px 12px;
+  text-align: left;
+  vertical-align: top;
+}
+th { background: var(--panel-2); color: var(--text); }
+td { color: var(--muted); }
+
+/* Callouts */
+.callout {
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent-2);
+  background: var(--bg-soft);
+  border-radius: 8px;
+  padding: 14px 16px;
+  margin: 18px 0;
+}
+.callout.warn { border-left-color: var(--warn); }
+.callout.danger { border-left-color: var(--danger); }
+.callout p { margin: 0; }
+.callout strong { color: var(--text); }
+
+/* Footer */
+.footer {
+  border-top: 1px solid var(--border);
+  padding: 28px 0 48px;
+  color: var(--muted);
+  font-size: 14px;
+}
+.footer a { color: var(--muted); }
+.footer a:hover { color: var(--text); }
+
+/* Page navigation (prev/next) */
+.pager {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  margin-top: 48px;
+  flex-wrap: wrap;
+}
+.pager a {
+  flex: 1 1 240px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 14px 18px;
+}
+.pager a:hover { border-color: var(--accent); text-decoration: none; }
+.pager .dir { font-size: 12px; color: var(--muted); font-family: var(--mono); }
+.pager .ttl { color: var(--text); font-weight: 600; }
+.pager .next { text-align: right; }

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Getting Started — hve-squad</title>
+  <meta name="description" content="Prerequisites, installing the hve-squad APM package, and your first squad run." />
+  <link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="index.html">hve<span class="dot">-</span>squad</a>
+      <div class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="getting-started.html" class="active">Getting Started</a>
+        <a href="usage.html">Usage</a>
+        <a href="maintaining.html">Maintaining</a>
+        <a href="troubleshooting.html">Troubleshooting</a>
+        <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="hero">
+    <div class="container">
+      <div class="eyebrow">Consumer Guide</div>
+      <h1>Getting Started</h1>
+      <p class="lead">
+        Everything a consumer needs to install the package, deploy it to Copilot, and run the
+        squad for the first time.
+      </p>
+    </div>
+  </header>
+
+  <main class="content">
+    <div class="container">
+      <h2>Prerequisites</h2>
+      <ul>
+        <li>PowerShell 7+</li>
+        <li>Git</li>
+        <li>APM CLI installed and available in <code>PATH</code></li>
+        <li>Access to the <a href="https://github.com/microsoft/hve-core">microsoft/hve-core</a> repository</li>
+      </ul>
+
+      <h2>1. Install the package</h2>
+      <p>Run <code>apm install</code> from the root of the project you want the squad in.</p>
+
+      <div class="callout warn">
+        <p>
+          <strong>Heads-up (APM 0.18.0+).</strong> APM no longer silently defaults to the Copilot
+          harness. In a project with no existing <code>.github/agents/</code>,
+          <code>.github/prompts/</code>, <code>.github/instructions/</code>, <code>.claude/</code>,
+          <code>.cursor/</code>, etc., <code>apm install</code> fails with
+          <code>[x] No harness detected</code> <em>after</em> downloading sources into
+          <code>apm_modules/</code> but <em>before</em> deploying anything into
+          <code>.github/</code>. Tell APM which harness to deploy to using one of the options below.
+        </p>
+      </div>
+
+      <h3>Option A — pass <code>--target copilot</code> on every install (one-off)</h3>
+      <pre><code>apm install "Peter-N91/hve-squad#vX.Y.z" --target copilot  # pinned (recommended)
+# or
+apm install Peter-N91/hve-squad --target copilot           # latest on default branch</code></pre>
+
+      <h3>Option B — declare the target once in your project's <code>apm.yml</code> (persistent, recommended)</h3>
+      <p>Create an <code>apm.yml</code> at the root of your consumer project:</p>
+      <pre><code>name: my-project
+version: 0.1.0
+targets:
+  - copilot</code></pre>
+      <p>
+        Then <code>apm install "Peter-N91/hve-squad#vX.Y.z"</code> (no flag needed) deploys to
+        Copilot from now on. This also makes future <code>apm install</code> / <code>apm update</code>
+        runs reproducible.
+      </p>
+      <p>
+        Either way, this deploys the bundled HVE Core agents, prompts, instructions, and skills —
+        plus the squad — into your project's <code>.github/</code> tree. Consumers do <strong>not</strong>
+        need <code>sync-deps</code> or <code>install-sync</code>; those are maintainer-only scripts.
+      </p>
+
+      <div class="callout">
+        <p>
+          <strong>If your first install already failed with <code>No harness detected</code>:</strong>
+          the sources are already in <code>apm_modules/</code>. Re-run with <code>--target copilot</code>
+          (Option A) or add the <code>targets:</code> block to <code>apm.yml</code> (Option B) and
+          re-run <code>apm install</code>; APM re-runs the deploy step and populates
+          <code>.github/</code>.
+        </p>
+      </div>
+
+      <h2>2. Run the squad</h2>
+      <p>
+        The squad is a user-invocable Squad Coordinator that routes your request to a cast of HVE
+        Core agents and persists its state under <code>.copilot-tracking/squad/</code>. Invoke it
+        with the <code>/squad</code> prompt in Copilot Chat:
+      </p>
+      <pre><code>/squad request="add input validation to the login form"</code></pre>
+      <p>
+        On a fresh project the coordinator inspects your repo and proposes a profile before creating
+        anything. See <a href="usage.html">Usage</a> for profiles, autonomy modes, and remote
+        approval.
+      </p>
+
+      <h2>3. Rebuild (re-deploy) after updating</h2>
+      <p>
+        To pull a newer version of the package or refresh your deployed assets, re-run install with
+        the version tag you want (include <code>--target copilot</code> if you have not declared
+        <code>targets:</code> in your project's <code>apm.yml</code>):
+      </p>
+      <pre><code>apm install "Peter-N91/hve-squad#vX.Y.z" --target copilot</code></pre>
+      <p>
+        <code>apm install</code> re-flattens the package into <code>.github/</code>. Your squad
+        <strong>state</strong> under <code>.copilot-tracking/squad/</code> is created per-project and
+        is never packaged, so re-installing does not overwrite your roster, routing, decisions, or
+        history.
+      </p>
+
+      <div class="pager">
+        <a class="prev" href="index.html">
+          <div class="dir">← Back</div>
+          <div class="ttl">Home</div>
+        </a>
+        <a class="next" href="usage.html">
+          <div class="dir">Next →</div>
+          <div class="ttl">Usage</div>
+        </a>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        hve-squad · built on <a href="https://github.com/microsoft/hve-core">Microsoft HVE Core</a>
+        agents and conventions · <a href="https://github.com/Peter-N91/hve-squad">Source on GitHub</a>
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,126 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>hve-squad — APM package for HVE Core + Squad</title>
+  <meta name="description" content="An installable APM package that bundles HVE Core agents, prompts, instructions, and skills with a Squad Coordinator for Copilot." />
+  <link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="index.html">hve<span class="dot">-</span>squad</a>
+      <div class="nav-links">
+        <a href="index.html" class="active">Home</a>
+        <a href="getting-started.html">Getting Started</a>
+        <a href="usage.html">Usage</a>
+        <a href="maintaining.html">Maintaining</a>
+        <a href="troubleshooting.html">Troubleshooting</a>
+        <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="hero">
+    <div class="container">
+      <div class="eyebrow">APM Package · Copilot</div>
+      <h1>HVE Core agents and a Squad Coordinator, in one install.</h1>
+      <p class="lead">
+        hve-squad assembles HVE Core agents, prompts, instructions, and skills into a single
+        installable bundle, and ships a Squad Coordinator that routes your request to a cast of
+        agents in parallel. Install once, then run <code>/squad</code>.
+      </p>
+      <a class="btn btn-primary" href="getting-started.html">Get started</a>
+      <a class="btn btn-ghost" href="usage.html">Run the squad</a>
+      <a class="btn btn-ghost" href="https://github.com/Peter-N91/hve-squad">View on GitHub</a>
+    </div>
+  </header>
+
+  <main>
+    <section class="section">
+      <div class="container">
+        <p class="section-label">Start here</p>
+        <div class="grid">
+          <a class="card" href="getting-started.html">
+            <div class="icon">🚀</div>
+            <h3>Getting Started</h3>
+            <p>Prerequisites, installing the package with the correct target, and your first run.</p>
+            <span class="tag">Install</span>
+          </a>
+          <a class="card" href="usage.html">
+            <div class="icon">🤖</div>
+            <h3>Run the Squad</h3>
+            <p>Profiles, autonomy modes, remote approval, and how the coordinator routes work.</p>
+            <span class="tag">Consumer</span>
+          </a>
+          <a class="card" href="maintaining.html">
+            <div class="icon">🔧</div>
+            <h3>Maintaining</h3>
+            <p>Dependency generation, the author workflow, customization, and the release process.</p>
+            <span class="tag">Author</span>
+          </a>
+          <a class="card" href="troubleshooting.html">
+            <div class="icon">🩺</div>
+            <h3>Troubleshooting</h3>
+            <p>Known install errors with copy-paste fixes, versioning, and repository notes.</p>
+            <span class="tag">Reference</span>
+          </a>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <p class="section-label">What this project does</p>
+        <p>
+          This repository provides a curated APM package that references content from
+          <a href="https://github.com/microsoft/hve-core">microsoft/hve-core</a> under
+          <code>.github/agents</code>, <code>.github/instructions</code>,
+          <code>.github/prompts</code>, and <code>.github/skills</code>. Instead of hand-maintaining
+          hundreds of dependency paths, an automation script regenerates the dependency list in
+          <code>apm.yml</code>.
+        </p>
+        <div class="grid">
+          <div class="card">
+            <div class="icon">📦</div>
+            <h3>One bundle</h3>
+            <p>Auto-discovers supported markdown artifacts from selected HVE Core folders and ships them together.</p>
+          </div>
+          <div class="card">
+            <div class="icon">♻️</div>
+            <h3>Reproducible</h3>
+            <p>Dependencies are resolved into <code>apm.lock.yaml</code> so installs are repeatable.</p>
+          </div>
+          <div class="card">
+            <div class="icon">🧩</div>
+            <h3>Squad included</h3>
+            <p>A locally authored Squad Coordinator plus supporting agents, instructions, a prompt, and a skill.</p>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section class="section">
+      <div class="container">
+        <p class="section-label">Quick install</p>
+        <pre><code># In the project you want the squad in:
+apm install "Peter-N91/hve-squad#v0.4.1" --target copilot</code></pre>
+        <p>
+          Then invoke the coordinator from Copilot Chat with the <code>/squad</code> prompt. See
+          <a href="getting-started.html">Getting Started</a> for the full flow.
+        </p>
+      </div>
+    </section>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        hve-squad · built on <a href="https://github.com/microsoft/hve-core">Microsoft HVE Core</a>
+        agents and conventions · <a href="https://github.com/Peter-N91/hve-squad">Source on GitHub</a>
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/maintaining.html
+++ b/docs/maintaining.html
@@ -1,0 +1,220 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Maintaining — hve-squad</title>
+  <meta name="description" content="Maintainer workflow, dependency generation, squad source layout, customization, and the release process." />
+  <link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="index.html">hve<span class="dot">-</span>squad</a>
+      <div class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="getting-started.html">Getting Started</a>
+        <a href="usage.html">Usage</a>
+        <a href="maintaining.html" class="active">Maintaining</a>
+        <a href="troubleshooting.html">Troubleshooting</a>
+        <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="hero">
+    <div class="container">
+      <div class="eyebrow">Author Guide</div>
+      <h1>Maintaining the Package</h1>
+      <p class="lead">
+        The author workflow for regenerating dependencies, the squad source layout, customization
+        knobs, and the tag-based release process.
+      </p>
+    </div>
+  </header>
+
+  <main class="content">
+    <div class="container">
+      <h2>Repository structure</h2>
+      <ul>
+        <li><code>apm.yml</code>: package metadata, dependency list, and scripts</li>
+        <li><code>apm.lock.yaml</code>: resolved dependency lock file</li>
+        <li><code>scripts/Update-ApmDependencies.ps1</code>: dependency generator</li>
+        <li><code>squad-src/.github/</code>: locally authored squad source (agents, prompts, instructions, skills)</li>
+        <li><code>apm_modules/</code>: installed dependencies (ignored by git)</li>
+        <li><code>.github/</code>: generated/deployed local assets (ignored by git, except <code>.github/workflows/</code> if tracked)</li>
+        <li><code>docs/</code>: this documentation site (served by GitHub Pages)</li>
+      </ul>
+
+      <h2>Scripts</h2>
+      <p>Defined in <code>apm.yml</code>:</p>
+      <ul>
+        <li><code>sync-deps</code> — regenerates <code>dependencies.apm</code> from HVE Core content.</li>
+        <li><code>install-sync</code> — regenerates <code>dependencies.apm</code> and runs <code>apm install</code>.</li>
+      </ul>
+
+      <h2>Maintainer workflow</h2>
+      <ol>
+        <li>
+          Regenerate dependencies:
+          <pre><code>apm run sync-deps</code></pre>
+        </li>
+        <li>
+          Install dependencies locally:
+          <pre><code>apm install
+# or
+apm run install-sync</code></pre>
+        </li>
+        <li>
+          Refresh lockfile:
+          <pre><code>apm lock</code></pre>
+        </li>
+        <li>
+          [OPTIONAL] Build package artifact (only needed to build a plugin):
+          <pre><code>apm pack</code></pre>
+        </li>
+        <li>
+          [OPTIONAL] Publish (if applicable):
+          <pre><code>apm publish</code></pre>
+        </li>
+      </ol>
+      <p>Recommended sequence before release:</p>
+      <ol>
+        <li><code>apm run sync-deps</code></li>
+        <li><code>apm lock</code></li>
+        <li><code>apm pack</code> (optional)</li>
+      </ol>
+
+      <h2>How dependency generation works</h2>
+      <p>The generator script:</p>
+      <ul>
+        <li>Connects to <code>microsoft/hve-core</code> at a target ref (default: <code>main</code>)</li>
+        <li>Enumerates files under <code>.github/agents</code>, <code>.github/instructions</code>, <code>.github/prompts</code>, and <code>.github/skills</code></li>
+        <li>Filters for markdown artifacts</li>
+        <li>Rewrites only <code>dependencies.apm</code> in <code>apm.yml</code></li>
+      </ul>
+      <p>This keeps package metadata stable while updating the dependency list safely.</p>
+
+      <h2>Squad source</h2>
+      <p>
+        In addition to the <code>microsoft/hve-core</code> dependencies, this package ships a locally
+        authored "squad" — a Squad Coordinator plus supporting agents, instructions, a prompt, and a
+        skill. The squad source lives under:
+      </p>
+      <ul>
+        <li><code>squad-src/.github/agents/squad/</code></li>
+        <li><code>squad-src/.github/instructions/squad/</code></li>
+        <li><code>squad-src/.github/prompts/squad/</code></li>
+        <li><code>squad-src/.github/skills/squad/</code></li>
+      </ul>
+
+      <h3>Why the source is separate from the deployed <code>.github/</code> tree</h3>
+      <p>
+        <code>apm install</code> deploys agents and prompts <em>flattened</em> into the consumer's
+        <code>.github/</code> tree. If the squad source lived directly under the top-level
+        <code>.github/agents/</code> (or <code>.github/prompts/</code>), a later <code>apm install</code>
+        would clobber it. Keeping the authored source under <code>squad-src/.github/...</code> places it
+        outside the deploy flatten zone while preserving the
+        <code>.github/{agents,prompts,instructions,skills}/</code> prefix the deploy mapping expects.
+        Runtime squad <em>state</em> is created per-project under <code>.copilot-tracking/squad/</code>
+        and is never packaged.
+      </p>
+
+      <h3>How squad entries are generated</h3>
+      <p>
+        <code>Update-ApmDependencies.ps1</code> enumerates the squad source from the <em>local</em>
+        filesystem (it is not cloned, because the source lives in this working tree and may not be
+        pushed yet). Squad entries are emitted as remote virtual paths of the form
+        <code>&lt;SquadRepoSlug&gt;/&lt;SquadSourceRoot&gt;/.github/...</code>, for example
+        <code>Peter-N91/hve-squad/squad-src/.github/agents/squad/squad-coordinator.agent.md</code>.
+        They are appended after the hve-core entries in <code>dependencies.apm</code>.
+      </p>
+      <p>The sync command accepts two squad-specific parameters:</p>
+      <pre><code>pwsh -File scripts/Update-ApmDependencies.ps1 `
+  -SquadSourceRoot squad-src `
+  -SquadRepoSlug Peter-N91/hve-squad</code></pre>
+      <ul>
+        <li><code>SquadSourceRoot</code>: local path to the squad source tree (default: <code>squad-src</code>). If the path does not exist, squad enumeration is skipped without error.</li>
+        <li><code>SquadRepoSlug</code>: <code>owner/repo</code> that hosts the squad source (default: <code>Peter-N91/hve-squad</code>).</li>
+      </ul>
+      <p>Use <code>-DryRun</code> to preview both the hve-core and squad entries without writing <code>apm.yml</code>.</p>
+
+      <div class="callout">
+        <p>
+          <code>apm lock</code> and <code>apm install</code> can only resolve the squad virtual paths
+          once the <code>squad-src/</code> tree has been pushed to the <code>SquadRepoSlug</code> remote.
+          Until then, <code>apm.yml</code> lists the squad entries but <code>apm.lock.yaml</code> will not
+          record them.
+        </p>
+      </div>
+
+      <h2>Customization</h2>
+      <p>You can tune generation behavior in <code>scripts/Update-ApmDependencies.ps1</code>:</p>
+      <ul>
+        <li><code>RepoSlug</code>: source repository</li>
+        <li><code>Ref</code>: branch/tag/commit to scan</li>
+        <li><code>IncludeRoots</code>: folders included in discovery</li>
+        <li><code>IncludeRegex</code>: file filter pattern</li>
+        <li><code>SquadSourceRoot</code>: local squad source tree path</li>
+        <li><code>SquadRepoSlug</code>: <code>owner/repo</code> hosting the squad source</li>
+      </ul>
+
+      <h2>Release process</h2>
+      <p>
+        Releases use a tag-based flow on top of the default branch (<code>main</code>). The tag is the
+        release artifact consumers install with <code>apm install "Peter-N91/hve-squad#vX.Y.Z"</code>.
+      </p>
+      <ol>
+        <li>
+          Cut a release branch from <code>main</code>:
+          <pre><code>git checkout main
+git pull
+git checkout -b release/vX.Y.Z</code></pre>
+        </li>
+        <li>
+          Update version metadata:
+          <ul>
+            <li>Bump <code>version:</code> in <code>apm.yml</code> to <code>X.Y.Z</code>.</li>
+            <li>Add a <code>## [X.Y.Z]</code> section to <code>CHANGELOG.md</code> describing the changes.</li>
+            <li>Refresh the lockfile if dependencies changed: <code>apm run sync-deps</code> then <code>apm lock</code>.</li>
+          </ul>
+        </li>
+        <li>Open a PR into <code>main</code> titled <code>release: vX.Y.Z</code> (the PR template fills in the checklist).</li>
+        <li>
+          After the PR is merged, tag the merge commit on <code>main</code> and push the tag:
+          <pre><code>git checkout main
+git pull
+git tag -a vX.Y.Z -m "Release vX.Y.Z"
+git push origin vX.Y.Z</code></pre>
+        </li>
+        <li>(Optional) Publish a GitHub Release for the tag.</li>
+      </ol>
+      <p>
+        Avoid a long-lived <code>release</code> branch. Only create <code>release/vX.Y.z</code> from an
+        existing tag when you need to patch an older version after newer work has landed on
+        <code>main</code>.
+      </p>
+
+      <div class="pager">
+        <a class="prev" href="usage.html">
+          <div class="dir">← Back</div>
+          <div class="ttl">Usage</div>
+        </a>
+        <a class="next" href="troubleshooting.html">
+          <div class="dir">Next →</div>
+          <div class="ttl">Troubleshooting</div>
+        </a>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        hve-squad · built on <a href="https://github.com/microsoft/hve-core">Microsoft HVE Core</a>
+        agents and conventions · <a href="https://github.com/Peter-N91/hve-squad">Source on GitHub</a>
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Troubleshooting — hve-squad</title>
+  <meta name="description" content="Known install errors with copy-paste fixes, versioning, and repository notes." />
+  <link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="index.html">hve<span class="dot">-</span>squad</a>
+      <div class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="getting-started.html">Getting Started</a>
+        <a href="usage.html">Usage</a>
+        <a href="maintaining.html">Maintaining</a>
+        <a href="troubleshooting.html" class="active">Troubleshooting</a>
+        <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="hero">
+    <div class="container">
+      <div class="eyebrow">Reference</div>
+      <h1>Troubleshooting</h1>
+      <p class="lead">Known issues with copy-paste fixes, plus versioning and repository notes.</p>
+    </div>
+  </header>
+
+  <main class="content">
+    <div class="container">
+      <h2>Common issues</h2>
+
+      <h3><code>[x] No harness detected</code> after <code>apm install</code> (APM 0.18.0+)</h3>
+      <p>
+        APM downloaded the sources into <code>apm_modules/</code> but skipped the deploy step because
+        no harness marker was found in your project (no <code>.github/agents/</code>,
+        <code>.github/prompts/</code>, <code>.claude/</code>, <code>.cursor/</code>, etc.). Re-run with
+        <code>--target copilot</code>:
+      </p>
+      <pre><code>apm install "Peter-N91/hve-squad#vX.Y.z" --target copilot</code></pre>
+      <p>
+        Or add a <code>targets:</code> block to your project's <code>apm.yml</code> so future installs
+        work without the flag (see <a href="getting-started.html">Getting Started → Option B</a>).
+      </p>
+
+      <h3><code>apm_modules/</code> populated but <code>.github/</code> is empty and no error visible</h3>
+      <p>
+        Same root cause as above — scroll up in your terminal for the <code>No harness detected</code>
+        message and apply the <code>--target copilot</code> fix.
+      </p>
+
+      <h3>No scripts found</h3>
+      <p>Check the <code>scripts</code> block in <code>apm.yml</code> and run <code>apm list</code>.</p>
+
+      <h3>Access failures to HVE Core</h3>
+      <p>Confirm git authentication and repository visibility.</p>
+
+      <h3>Dependencies look stale</h3>
+      <p>Run <code>apm run sync-deps</code>, then <code>apm lock</code>.</p>
+
+      <h3><code>.github</code> still appears in git status after ignoring</h3>
+      <p>
+        Run <code>git rm -r --cached .github</code> once, then
+        <code>git add .github/workflows</code> (if you track workflows here), then commit.
+      </p>
+
+      <h2>Versioning</h2>
+      <ul>
+        <li>Releases follow <a href="https://semver.org/">Semantic Versioning</a>.</li>
+        <li>See <a href="https://github.com/Peter-N91/hve-squad/blob/main/CHANGELOG.md">CHANGELOG.md</a> for what is included in each version.</li>
+        <li>Consumers can pin to a tagged version, for example <code>apm install "Peter-N91/hve-squad#vX.Y.z"</code>.</li>
+      </ul>
+
+      <h2>Notes</h2>
+      <ul>
+        <li><code>.gitignore</code> ignores <code>apm_modules/</code>, generated <code>.github</code> assets, and keeps <code>.github/workflows/</code> tracked.</li>
+        <li>The package remains reproducible through <code>apm.lock.yaml</code>.</li>
+      </ul>
+
+      <div class="pager">
+        <a class="prev" href="maintaining.html">
+          <div class="dir">← Back</div>
+          <div class="ttl">Maintaining</div>
+        </a>
+        <a class="next" href="index.html">
+          <div class="dir">Next →</div>
+          <div class="ttl">Home</div>
+        </a>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        hve-squad · built on <a href="https://github.com/microsoft/hve-core">Microsoft HVE Core</a>
+        agents and conventions · <a href="https://github.com/Peter-N91/hve-squad">Source on GitHub</a>
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Usage — hve-squad</title>
+  <meta name="description" content="Run the squad: inputs, profiles, autonomy modes, remote approval, and first-run Init Mode." />
+  <link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="index.html">hve<span class="dot">-</span>squad</a>
+      <div class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="getting-started.html">Getting Started</a>
+        <a href="usage.html" class="active">Usage</a>
+        <a href="maintaining.html">Maintaining</a>
+        <a href="troubleshooting.html">Troubleshooting</a>
+        <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="hero">
+    <div class="container">
+      <div class="eyebrow">Consumer Guide</div>
+      <h1>Running the Squad</h1>
+      <p class="lead">
+        The Squad Coordinator routes your request to a cast of HVE Core agents, runs eligible roles
+        in parallel, and persists roster, routing, decisions, and history under
+        <code>.copilot-tracking/squad/</code>.
+      </p>
+    </div>
+  </header>
+
+  <main class="content">
+    <div class="container">
+      <h2>Invoke the coordinator</h2>
+      <pre><code>/squad request="add input validation to the login form"</code></pre>
+
+      <h3>Optional inputs</h3>
+      <ul>
+        <li>
+          <code>profile=default|full|security|design|architecture</code> — seeds which cast is
+          created on first run. If omitted on a fresh project, the coordinator inspects your repo and
+          proposes a recommended profile before creating anything.
+        </li>
+        <li>
+          <code>tier=fast|default</code> — a per-turn model-tier hint that overrides the
+          coordinator's cost-first defaults.
+        </li>
+        <li>
+          <code>mode=autonomous|autopilot</code> — the autonomy mode for this turn. Omit it to run
+          interactively, approving each step.
+        </li>
+      </ul>
+      <pre><code>/squad request="threat-model the auth service" profile=security
+/squad request="summarize the data layer" tier=fast
+/squad request="build the booking service end to end" mode=autopilot</code></pre>
+
+      <h2>Autonomy modes</h2>
+      <p>How much the squad does before it asks you:</p>
+      <table>
+        <thead>
+          <tr><th>Mode</th><th>How to run it</th><th>Who approves what</th></tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Interactive (default)</td>
+            <td>no <code>mode</code> flag</td>
+            <td>You approve <strong>each step</strong> (research, plan, implement, review). A ping fires at every step gate.</td>
+          </tr>
+          <tr>
+            <td><code>mode=autonomous</code></td>
+            <td><code>mode=autonomous</code></td>
+            <td>A narrow validator loop: the council re-validates one implementer output (max 2 cycles), then returns.</td>
+          </tr>
+          <tr>
+            <td><code>mode=autopilot</code></td>
+            <td><code>mode=autopilot</code></td>
+            <td>The squad runs research → plan → implement → review on its own and asks you <strong>only</strong> for impactful actions (deploy, <code>git push</code>, merge, schema/data changes) and to validate the <strong>final outcome</strong>.</td>
+          </tr>
+        </tbody>
+      </table>
+      <p>
+        Autopilot is the "tell it once, let it run" mode: it sequences the whole pipeline
+        autonomously but always stops for a human before anything irreversible and before release.
+        The two impactful/final stop-points fire a notification through the approval channel you
+        choose at build time (interactive mode pings you at every step instead).
+      </p>
+
+      <h2>Approving remotely (unattended / VM runs)</h2>
+      <p>
+        If you run the squad on a VM for a long job, pick the <code>github-issue</code> approval
+        channel at build time. At each gate the squad opens a GitHub issue, assigns and @mentions you
+        (so you get a GitHub mobile push), and waits. You approve from your phone with a comment —
+        <code>/approve</code>, <code>/approve-all</code>, <code>/changes: &lt;note&gt;</code>, or
+        <code>/stop</code> — or a <code>squad/*</code> label, without touching the VM. Only your
+        registered handle (or a repo collaborator) can approve, and only those keywords act.
+      </p>
+      <p>
+        The other channels are <code>webhook</code> (an outbound Teams/Slack/Discord ping only) and
+        <code>in-chat</code> (the default, which needs you at the PC). No channel requires the package
+        to ship an email or chat transport — when a channel's tooling is absent it degrades to an
+        in-chat approval, and the squad never proceeds on a timeout.
+      </p>
+
+      <h3>Remote approval setup (one-time, only for <code>github-issue</code>)</h3>
+      <p>Local and in-chat runs need nothing extra. To approve remotely from a VM run, set up the channel once:</p>
+      <ol>
+        <li>
+          <strong>Authenticate GitHub on the run host.</strong> Either run <code>gh auth login</code>
+          (the <code>gh</code> CLI is sufficient on a headless VM) or configure the official
+          <code>github</code> MCP server. The package ships a reference entry in
+          <code>.github/skills/squad/mcp.template.json</code> you can merge into your
+          <code>.vscode/mcp.json</code>; the GitHub MCP is preferred when present, and the squad falls
+          back to <code>gh</code>, then to in-chat. The token needs <code>repo</code> +
+          <code>issues</code> scope.
+        </li>
+        <li>
+          <strong>Install the approval watcher.</strong> Copy the reference workflow
+          <code>.github/skills/squad/github-approval-watcher.workflow.yml</code> to
+          <code>.github/workflows/squad-approval-watcher.yml</code> in the repo that hosts your
+          approval issues, then commit it. It relays your <code>/approve</code>,
+          <code>/approve-all</code>, <code>/changes:</code>, or <code>/stop</code> reply back so the
+          run resumes — and only an authorized handle's recognized keyword acts (free-form comment
+          text is never executed as a command).
+        </li>
+        <li>
+          <strong>Pick <code>github-issue</code> at build time</strong> and give the coordinator the
+          GitHub handle to @mention and the <code>owner/repo</code> for approval issues (defaults to
+          the current repo).
+        </li>
+      </ol>
+
+      <h2>First run (Init Mode)</h2>
+      <p>
+        When a project has no <code>.copilot-tracking/squad/team.md</code>, the coordinator proposes a
+        squad profile, waits for your confirmation, asks for an optional approval channel
+        (<code>github-issue</code> for remote/phone approval, <code>webhook</code>, or
+        <code>in-chat</code>), then seeds <code>team.md</code>, <code>routing.md</code>,
+        <code>decisions.md</code>, <code>notifications.md</code>, <code>state.json</code>, and a
+        <code>history/</code> directory. It never writes files before you confirm. After that, each
+        <code>/squad</code> call routes against the seeded roster.
+      </p>
+
+      <h2>Profiles</h2>
+      <p>The cast each profile seeds:</p>
+      <table>
+        <thead>
+          <tr><th>Profile</th><th>Members</th><th>Use when</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>default</code></td><td>lead, researcher, developer, tester, scribe</td><td>General-purpose work; recommended starting point</td></tr>
+          <tr><td><code>full</code></td><td>all 10 deployed roles</td><td>Complex, cross-cutting projects</td></tr>
+          <tr><td><code>security</code></td><td>security, rai, fact-checker, researcher, scribe</td><td>Security, threat-modeling, responsible-AI focus</td></tr>
+          <tr><td><code>design</code></td><td>designer, researcher, lead, tester, scribe</td><td>UX/UI and product-design focus</td></tr>
+          <tr><td><code>architecture</code></td><td>architect, researcher, lead, developer, scribe</td><td>System design and architecture focus</td></tr>
+        </tbody>
+      </table>
+
+      <h3>Requirements for running the squad</h3>
+      <ul>
+        <li>A <code>runSubagent</code> or <code>task</code> tool must be enabled so the coordinator can dispatch the cast.</li>
+        <li>The memory tool should be available for durable per-agent notes under <code>/memories/repo/</code>.</li>
+        <li>For the <code>github-issue</code> approval channel only: an authenticated <code>gh</code> CLI or <code>github</code> MCP on the run host, and the approval-watcher workflow installed. Interactive and in-chat runs need neither.</li>
+      </ul>
+      <p>
+        You can re-cast the squad later by editing <code>.copilot-tracking/squad/team.md</code> or
+        asking the coordinator to switch profiles.
+      </p>
+
+      <div class="pager">
+        <a class="prev" href="getting-started.html">
+          <div class="dir">← Back</div>
+          <div class="ttl">Getting Started</div>
+        </a>
+        <a class="next" href="maintaining.html">
+          <div class="dir">Next →</div>
+          <div class="ttl">Maintaining</div>
+        </a>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        hve-squad · built on <a href="https://github.com/microsoft/hve-core">Microsoft HVE Core</a>
+        agents and conventions · <a href="https://github.com/Peter-N91/hve-squad">Source on GitHub</a>
+      </p>
+    </div>
+  </footer>
+</body>
+</html>


### PR DESCRIPTION
- add docs/ static site with landing, usage, maintaining, troubleshooting pages
- add .github/workflows/docs.yml to publish docs/ to GitHub Pages
- trim README to a short landing page linking the site
- bump version to 0.4.1 and add CHANGELOG entry

📄 - Generated by Copilot

<!--
Title convention: release: vX.Y.Z   (for releases)
                  type(scope): short description   (for regular changes)
-->

## Summary

<!-- One or two lines describing what this PR does. -->

## Target version

- Target version: **vX.Y.Z**
- Previous version: vX.Y.Z

## Type of change

- [ ] Release (version bump)
- [ ] Feature / new content
- [ ] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Changelog

- [ ] `CHANGELOG.md` has a `## [X.Y.Z]` section describing this release
- [ ] `apm.yml` `version:` is bumped to match (release PRs only)

## Release checklist (release PRs only)

- [ ] Branch named `release/vX.Y.Z`
- [ ] PR title is `release: vX.Y.Z`
- [ ] After merge, tag the merge commit: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
- [ ] Push the tag: `git push origin vX.Y.Z`
- [ ] (Optional) Publish a GitHub Release for the tag

## Notes

<!-- Anything reviewers should know: follow-ups, risks, manual steps. -->
