### PR TITLE
fix(workflows): auto-enable Pages and bump checkout to Node 24

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -29,12 +29,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
         with:
           persist-credentials: false
 
       - name: Configure Pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
+        with:
+          enablement: true
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0


### PR DESCRIPTION
- add enablement: true to configure-pages to fix Get Pages site Not Found
- bump actions/checkout to v6.0.3 to clear Node 20 deprecation warning

🔧 - Generated by Copilot

<!--
Title convention: release: vX.Y.Z   (for releases)
                  type(scope): short description   (for regular changes)
-->

## Summary

<!-- One or two lines describing what this PR does. -->

## Target version

- Target version: **vX.Y.Z**
- Previous version: vX.Y.Z

## Type of change

- [ ] Release (version bump)
- [ ] Feature / new content
- [ ] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Changelog

- [ ] `CHANGELOG.md` has a `## [X.Y.Z]` section describing this release
- [ ] `apm.yml` `version:` is bumped to match (release PRs only)

## Release checklist (release PRs only)

- [ ] Branch named `release/vX.Y.Z`
- [ ] PR title is `release: vX.Y.Z`
- [ ] After merge, tag the merge commit: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
- [ ] Push the tag: `git push origin vX.Y.Z`
- [ ] (Optional) Publish a GitHub Release for the tag

## Notes

<!-- Anything reviewers should know: follow-ups, risks, manual steps. -->
