### PR TITLE
docs: add hve-squad logo to site header and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,14 @@
-# hve-squad
+<p align="center">
+  <img src="docs/assets/logo.svg" alt="hve-squad logo" width="120" height="120" />
+</p>
 
-APM package that assembles HVE Core agents, prompts, instructions, and skills into one
-installable bundle for Copilot target environments, and ships a Squad Coordinator that routes
-your request to a cast of agents in parallel.
+<h1 align="center">hve-squad</h1>
+
+<p align="center">
+  APM package that assembles HVE Core agents, prompts, instructions, and skills into one
+  installable bundle for Copilot target environments, and ships a Squad Coordinator that routes
+  your request to a cast of agents in parallel.
+</p>
 
 ## Documentation
 

--- a/docs/assets/logo.svg
+++ b/docs/assets/logo.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-label="hve-squad logo" width="64" height="64">
+  <defs>
+    <linearGradient id="hsEdge" x1="0" y1="0" x2="64" y2="64" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#3ddc97"/>
+      <stop offset="1" stop-color="#5aa9ff"/>
+    </linearGradient>
+    <radialGradient id="hsCore" cx="32" cy="30" r="8" gradientUnits="userSpaceOnUse">
+      <stop offset="0" stop-color="#8ffccf"/>
+      <stop offset="1" stop-color="#3ddc97"/>
+    </radialGradient>
+  </defs>
+
+  <!-- Hexagon badge -->
+  <polygon
+    points="32,3 55.1,16.5 55.1,47.5 32,61 8.9,47.5 8.9,16.5"
+    fill="#11171f" stroke="url(#hsEdge)" stroke-width="2.5" stroke-linejoin="round"/>
+
+  <!-- Routing links: coordinator -> squad -->
+  <g stroke="#5aa9ff" stroke-width="2" stroke-linecap="round" opacity="0.55">
+    <line x1="32" y1="30" x2="32" y2="16"/>
+    <line x1="32" y1="30" x2="18" y2="44"/>
+    <line x1="32" y1="30" x2="46" y2="44"/>
+  </g>
+
+  <!-- Squad agent nodes -->
+  <g fill="#5aa9ff">
+    <circle cx="32" cy="16" r="4"/>
+    <circle cx="18" cy="44" r="4"/>
+    <circle cx="46" cy="44" r="4"/>
+  </g>
+
+  <!-- Coordinator core -->
+  <circle cx="32" cy="30" r="6.5" fill="url(#hsCore)" stroke="#06281c" stroke-width="1.5"/>
+
+  <!-- Command chevron inside the core -->
+  <path d="M29.6 27.4 L33 30 L29.6 32.6" fill="none" stroke="#06281c" stroke-width="1.6"
+        stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -64,12 +64,32 @@ a:hover { text-decoration: underline; }
   flex-wrap: wrap;
 }
 .brand {
+  display: inline-flex;
+  align-items: center;
+  gap: 9px;
   font-family: var(--mono);
   font-weight: 700;
   color: var(--text);
   letter-spacing: 0.5px;
 }
+.brand img { width: 28px; height: 28px; display: block; }
 .brand .dot { color: var(--accent); }
+
+/* Hero logo lockup */
+.hero-logo {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 22px;
+}
+.hero-logo img { width: 60px; height: 60px; }
+.hero-logo .wordmark {
+  font-family: var(--mono);
+  font-weight: 700;
+  font-size: 24px;
+  letter-spacing: 0.5px;
+}
+.hero-logo .wordmark .dot { color: var(--accent); }
 .nav-links {
   display: flex;
   gap: 16px;

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -5,12 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Getting Started — hve-squad</title>
   <meta name="description" content="Prerequisites, installing the hve-squad APM package, and your first squad run." />
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg" />
   <link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
   <nav class="nav">
     <div class="nav-inner">
-      <a class="brand" href="index.html">hve<span class="dot">-</span>squad</a>
+      <a class="brand" href="index.html"><img src="assets/logo.svg" alt="" />hve<span class="dot">-</span>squad</a>
       <div class="nav-links">
         <a href="index.html">Home</a>
         <a href="getting-started.html" class="active">Getting Started</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,12 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>hve-squad — APM package for HVE Core + Squad</title>
   <meta name="description" content="An installable APM package that bundles HVE Core agents, prompts, instructions, and skills with a Squad Coordinator for Copilot." />
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg" />
   <link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
   <nav class="nav">
     <div class="nav-inner">
-      <a class="brand" href="index.html">hve<span class="dot">-</span>squad</a>
+      <a class="brand" href="index.html"><img src="assets/logo.svg" alt="" />hve<span class="dot">-</span>squad</a>
       <div class="nav-links">
         <a href="index.html" class="active">Home</a>
         <a href="getting-started.html">Getting Started</a>
@@ -24,6 +25,10 @@
 
   <header class="hero">
     <div class="container">
+      <div class="hero-logo">
+        <img src="assets/logo.svg" alt="hve-squad logo" />
+        <span class="wordmark">hve<span class="dot">-</span>squad</span>
+      </div>
       <div class="eyebrow">APM Package · Copilot</div>
       <h1>HVE Core agents and a Squad Coordinator, in one install.</h1>
       <p class="lead">

--- a/docs/maintaining.html
+++ b/docs/maintaining.html
@@ -5,12 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Maintaining — hve-squad</title>
   <meta name="description" content="Maintainer workflow, dependency generation, squad source layout, customization, and the release process." />
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg" />
   <link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
   <nav class="nav">
     <div class="nav-inner">
-      <a class="brand" href="index.html">hve<span class="dot">-</span>squad</a>
+      <a class="brand" href="index.html"><img src="assets/logo.svg" alt="" />hve<span class="dot">-</span>squad</a>
       <div class="nav-links">
         <a href="index.html">Home</a>
         <a href="getting-started.html">Getting Started</a>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -5,12 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Troubleshooting — hve-squad</title>
   <meta name="description" content="Known install errors with copy-paste fixes, versioning, and repository notes." />
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg" />
   <link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
   <nav class="nav">
     <div class="nav-inner">
-      <a class="brand" href="index.html">hve<span class="dot">-</span>squad</a>
+      <a class="brand" href="index.html"><img src="assets/logo.svg" alt="" />hve<span class="dot">-</span>squad</a>
       <div class="nav-links">
         <a href="index.html">Home</a>
         <a href="getting-started.html">Getting Started</a>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -5,12 +5,13 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Usage — hve-squad</title>
   <meta name="description" content="Run the squad: inputs, profiles, autonomy modes, remote approval, and first-run Init Mode." />
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg" />
   <link rel="stylesheet" href="assets/style.css" />
 </head>
 <body>
   <nav class="nav">
     <div class="nav-inner">
-      <a class="brand" href="index.html">hve<span class="dot">-</span>squad</a>
+      <a class="brand" href="index.html"><img src="assets/logo.svg" alt="" />hve<span class="dot">-</span>squad</a>
       <div class="nav-links">
         <a href="index.html">Home</a>
         <a href="getting-started.html">Getting Started</a>


### PR DESCRIPTION
- add docs/assets/logo.svg (hexagon coordinator-and-squad mark)
- show logo in nav brand and favicon across all docs pages
- add hero logo lockup on landing page
- display logo at top of README

🎨 - Generated by Copilot

<!--
Title convention: release: vX.Y.Z   (for releases)
                  type(scope): short description   (for regular changes)
-->

## Summary

<!-- One or two lines describing what this PR does. -->

## Target version

- Target version: **vX.Y.Z**
- Previous version: vX.Y.Z

## Type of change

- [ ] Release (version bump)
- [ ] Feature / new content
- [ ] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Changelog

- [ ] `CHANGELOG.md` has a `## [X.Y.Z]` section describing this release
- [ ] `apm.yml` `version:` is bumped to match (release PRs only)

## Release checklist (release PRs only)

- [ ] Branch named `release/vX.Y.Z`
- [ ] PR title is `release: vX.Y.Z`
- [ ] After merge, tag the merge commit: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
- [ ] Push the tag: `git push origin vX.Y.Z`
- [ ] (Optional) Publish a GitHub Release for the tag

## Notes

<!-- Anything reviewers should know: follow-ups, risks, manual steps. -->
