### PR TITLE
feat(squad): add python-diagrams skill and docs demo page (v0.8.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,35 @@ All notable changes to this project are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.4] - 2026-06-19
+
+Adds a Python `diagrams` skill for committed Azure-icon architecture diagrams and a docs Demo page, and removes third-party accelerator references.
+
+### Added
+
+- `python-diagrams` skill (`squad-src/.github/skills/python-diagrams/`): renders committed Azure-icon HLD/LLD diagrams with the Python `diagrams` library on a Graphviz backend, emitting paired PNG + SVG via a shared `diagram_io` output helper. Ships an `azure-webapp-lld` template, a `requirements.txt`, and a `verify_installation.py` check, and is registered in `apm.yml` dependencies.
+- Docs Demo page (`docs/demo.html`) with a multi-demo chevron selector and a `Demo` entry added to the navigation across the docs site. Includes an Optional Azure-icon architecture diagrams section documenting the `uv` + Graphviz prerequisite and the one-clause `/squad` trigger.
+
+### Changed
+
+- Squad Azure Architect (`squad-src/.github/agents/squad/squad-azure-architect.agent.md`): the diagram-rendering step now follows a three-tier ladder — draw.io MCP when configured, the `python-diagrams` skill for a committed icon image, then Mermaid as the always-available fallback.
+- Demo doc `/squad` requests updated to the real tested workload (frontend + backend web apps, VNet/subnets, private endpoints, under $60, containerization left to the squad) for the autopilot one-request version and the Beat 1 (cost) and Beat 2 (architecture) examples.
+
+### Removed
+
+- All references to the third-party APEX accelerator across the changelog, the MCP reference template (`mcp.template.json`), the capability map (`squad-mcp-capability.instructions.md`), and the `azure-scaffold` skill.
+
+### Consumer install
+
+Pin to this version:
+
+```powershell
+apm install "Peter-N91/hve-squad#v0.8.4"
+```
+
+[0.8.4]: https://github.com/Peter-N91/hve-squad/releases/tag/v0.8.4
+
+
 ## [0.8.3] - 2026-06-19
 
 ### Changed
@@ -71,14 +100,14 @@ apm install "Peter-N91/hve-squad#v0.8.1"
 
 ## [0.8.0] - 2026-06-17
 
-Adds APEX Accelerator parity capabilities to the Azure squad: live Azure governance discovery, post-deployment as-built documentation, and resource-level triage and diagnosis — all delivered as two new read-only squad roles backed by the official `@azure/mcp` server, with named non-MCP fallbacks so a missing server never blocks the squad.
+Adds live Azure governance discovery, post-deployment as-built documentation, and resource-level triage and diagnosis to the Azure squad: all delivered as two new read-only squad roles backed by the official `@azure/mcp` server, with named non-MCP fallbacks so a missing server never blocks the squad.
 
 ### Added
 
 - `Squad As-Built Author` agent (`squad-src/.github/agents/squad/squad-asbuilt-author.agent.md`): a read-only post-deploy role that inventories deployed Azure resources via the `azure-resource` capability (`@azure/mcp` Resource Graph KQL preferred, `az` CLI / Resource Manager REST fallback), builds a compliance matrix from Azure Policy state, and drafts an operations runbook and backup/DR plan for Doc Ops to publish. Never deploys, mutates resources, or authors IaC.
 - `Squad Azure Diagnose` agent (`squad-src/.github/agents/squad/squad-azure-diagnose.agent.md`): a strictly read-only Azure troubleshooting role that queries Resource Health, Azure Monitor/Log Analytics KQL, and Resource Graph to correlate ranked hypotheses and recommend (never apply) remediations. Defers every change to the gated Squad Deployer or Squad IaC Author.
 - `azure-resource` MCP capability row in the capability map (`squad-src/.github/instructions/squad/squad-mcp-capability.instructions.md`): maps the new `azure-resource` capability to `@azure/mcp` with a named `az` CLI / Resource Graph REST fallback, following the existing graceful-degradation contract.
-- Official `@azure/mcp` server wired into the MCP reference template (`squad-src/.github/skills/squad/mcp.template.json`): stdio entry invoking `@azure/mcp@latest server start`, authenticated via `DefaultAzureCredential` / `az login` with no stored secrets. A community Azure pricing MCP recommendation replaces the prior placeholder (primary: `msftnadavbh/AzurePricingMCP`; APEX-fork alternative available), with a labeled WI-02 placeholder for the unverified exact stdio invocation.
+- Official `@azure/mcp` server wired into the MCP reference template (`squad-src/.github/skills/squad/mcp.template.json`): stdio entry invoking `@azure/mcp@latest server start`, authenticated via `DefaultAzureCredential` / `az login` with no stored secrets. A community Azure pricing MCP recommendation replaces the prior placeholder (primary: `msftnadavbh/AzurePricingMCP`), with a labeled WI-02 placeholder for the unverified exact stdio invocation.
 - Read-only Azure Policy precheck on the Squad Deployer (`squad-src/.github/agents/squad/squad-deployer.agent.md`): a new step between the what-if/plan dry-run and the Impactful-Action Gate that queries effective Azure Policy assignments and compliance for the target scope, surfacing predicted denials before approval. The gate semantics, `confirm` tier, and Mandatory Escalation Triggers are unchanged.
 - `.vscode/mcp.json` entry in the azure-scaffold bundled templates and opt-in scaffolding flow (`squad-src/.github/skills/azure-scaffold/SKILL.md`): consumers can merge the squad MCP template into their workspace on request; the turnkey-via-scaffolding posture is documented in the skill overview. The APM package itself never writes consumer `.vscode/` or `.devcontainer/` trees.
 - Roster, routing, and profile wiring for both new roles (`squad-src/.github/instructions/squad/squad-roster.instructions.md`, `squad-routing.instructions.md`, `squad-src/.github/skills/squad/SKILL.md`): `asbuilt-author` at `confirm` tier (non-parallel), `azure-diagnose` at `auto` tier (parallel-eligible); both registered in the `azure` and `full` squad profiles. Pre-existing SKILL-vs-roster profile mirror drift for `iac-author`, `deployer`, and `modernizer` reconciled in the same edit.

--- a/apm.yml
+++ b/apm.yml
@@ -1,5 +1,5 @@
 name: hve-squad
-version: 0.8.3
+version: 0.8.4
 description: APM package for hve-core and squad together
 author: Peter-N91
 # Which agent platforms to deploy to.
@@ -277,6 +277,7 @@ dependencies:
     - Peter-N91/hve-squad/squad-src/.github/instructions/squad/squad-state.instructions.md
     - Peter-N91/hve-squad/squad-src/.github/prompts/squad/squad.prompt.md
     - Peter-N91/hve-squad/squad-src/.github/skills/azure-scaffold
+    - Peter-N91/hve-squad/squad-src/.github/skills/python-diagrams
     - Peter-N91/hve-squad/squad-src/.github/skills/squad
   mcp: []
 includes: auto

--- a/docs/assets/style.css
+++ b/docs/assets/style.css
@@ -292,3 +292,54 @@ td { color: var(--muted); }
 .pager .dir { font-size: 12px; color: var(--muted); font-family: var(--mono); }
 .pager .ttl { color: var(--text); font-weight: 600; }
 .pager .next { text-align: right; }
+
+/* Demo chevrons — multi-demo selector / stepper */
+.demo-switch { margin: 28px 0 8px; }
+.demo-switch .label {
+  font-family: var(--mono);
+  font-size: 12px;
+  letter-spacing: 2px;
+  text-transform: uppercase;
+  color: var(--muted);
+  margin-bottom: 10px;
+}
+.demo-chevrons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+  padding: 0;
+  margin: 0;
+  list-style: none;
+}
+.demo-chevrons li { margin: 0; }
+.demo-chevrons .chev {
+  display: inline-flex;
+  flex-direction: column;
+  justify-content: center;
+  min-height: 48px;
+  padding: 6px 20px 6px 30px;
+  background: var(--panel);
+  color: var(--muted);
+  text-decoration: none;
+  clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 50%, calc(100% - 14px) 100%, 0 100%, 14px 50%);
+}
+.demo-chevrons li:first-child .chev {
+  padding-left: 20px;
+  clip-path: polygon(0 0, calc(100% - 14px) 0, 100% 50%, calc(100% - 14px) 100%, 0 100%);
+}
+.demo-chevrons .chev .step {
+  font-family: var(--mono);
+  font-size: 11px;
+  letter-spacing: 1px;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+.demo-chevrons .chev .name { font-size: 13px; font-weight: 600; color: var(--text); }
+.demo-chevrons a.chev:hover { background: var(--panel-2); text-decoration: none; }
+.demo-chevrons a.chev:hover .step { color: var(--accent-2); }
+.demo-chevrons .chev.active { background: var(--accent); }
+.demo-chevrons .chev.active .step,
+.demo-chevrons .chev.active .name { color: #06231a; }
+.demo-chevrons .chev.soon { opacity: 0.55; cursor: default; }
+.demo-chevrons .chev.soon .step { color: var(--warn); }
+.demo-chevrons .chev.soon .name { color: var(--muted); }

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -1,0 +1,302 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Demo — hve-squad</title>
+  <meta name="description" content="A runnable Azure squad demo: cost, architecture, IaC, governance-checked deploy, as-built, and diagnose — plus an autonomous one-request version." />
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg" />
+  <link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="index.html"><img src="assets/logo.svg" alt="" />hve<span class="dot">-</span>squad</a>
+      <div class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="getting-started.html">Getting Started</a>
+        <a href="usage.html">Usage</a>
+        <a href="demo.html" class="active">Demo</a>
+        <a href="maintaining.html">Maintaining</a>
+        <a href="troubleshooting.html">Troubleshooting</a>
+        <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="hero">
+    <div class="container">
+      <div class="eyebrow">Walkthrough</div>
+      <h1>Azure Squad Demo</h1>
+      <p class="lead">
+        A runnable script for the <code>azure</code> profile that takes one workload from cost
+        estimate through architecture, IaC, a governance-checked deploy, as-built documentation, and
+        diagnosis — every beat from the single <code>/squad</code> entry point. The same arc also
+        runs as a single autonomous request. Every deploy stays behind a human gate; as-built and
+        diagnose are strictly read-only.
+      </p>
+    </div>
+  </header>
+
+  <main class="content">
+    <div class="container">
+
+      <div class="demo-switch">
+        <div class="label">Choose a demo</div>
+        <!--
+          Multi-demo selector. To add a demo: give it the next "Demo N" number,
+          turn its chevron into a link (<a class="chev" href="demo-N.html">),
+          mark the current page's chevron .active, and drop the .soon class once
+          the demo page exists.
+        -->
+        <ul class="demo-chevrons">
+          <li><span class="chev active"><span class="step">Demo 1</span><span class="name">Azure Squad</span></span></li>
+          <li><span class="chev soon"><span class="step">Demo 2</span><span class="name">Coming soon</span></span></li>
+          <li><span class="chev soon"><span class="step">Demo 3</span><span class="name">Coming soon</span></span></li>
+        </ul>
+      </div>
+
+      <h2>What you are proving</h2>
+      <p>
+        Each beat maps a capability to the squad role that owns it. This is the narration backbone —
+        the differentiator is that all of it ships as an APM package installed into <em>any</em>
+        repo, MCP-optional with graceful fallbacks, with a human gate on every deploy.
+      </p>
+      <table>
+        <thead>
+          <tr><th>Capability</th><th>Squad role</th><th>Notes</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>Cost estimate / pricing</td><td>Squad Cost Manager</td><td>Pricing MCP when wired, Azure Retail Prices REST fallback otherwise.</td></tr>
+          <tr><td>Architecture (HLD / LLD)</td><td>Squad Azure Architect</td><td>AVM modules + landing-zone patterns, Mermaid by default.</td></tr>
+          <tr><td>IaC codegen (Bicep / Terraform)</td><td>Squad IaC Author</td><td>Converts the LLD into <code>infra/{track}/{project}</code>; never deploys.</td></tr>
+          <tr><td>Governance precheck + deploy</td><td>Squad Deployer</td><td>Read-only Azure Policy precheck <em>before</em> the Impactful-Action Gate.</td></tr>
+          <tr><td>As-built documentation</td><td>Squad As-Built Author</td><td>Resource inventory, compliance matrix, runbook, DR plan — read-only.</td></tr>
+          <tr><td>Diagnose</td><td>Squad Azure Diagnose</td><td>Ranked hypotheses from Resource Health / Monitor / Resource Graph — read-only.</td></tr>
+          <tr><td>Research → Plan → Implement → Review</td><td>researcher, lead, developer, tester</td><td>The methodology spine, seeded into the <code>azure</code> profile alongside the specialists.</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Before you start</h2>
+      <p>
+        Point the read-only beats (as-built, diagnose) at an <strong>existing resource group</strong>
+        you already have. They then produce real output with zero deploy, zero spend, and zero risk.
+      </p>
+      <table>
+        <thead>
+          <tr><th>Prerequisite</th><th>Why</th><th>Check</th></tr>
+        </thead>
+        <tbody>
+          <tr><td>hve-squad <code>v0.8.1</code> installed</td><td>The methodology spine and the as-built/diagnose roles require <code>0.8.1</code>.</td><td><code>apm install "Peter-N91/hve-squad#v0.8.1"</code></td></tr>
+          <tr><td>Azure subscription + <code>az login</code></td><td>Real reads for cost / as-built / diagnose; optional deploy.</td><td><code>az account show</code></td></tr>
+          <tr><td>Node.js + <code>npx</code></td><td>Runs the optional <code>@azure/mcp</code> server.</td><td><code>node -v</code></td></tr>
+          <tr><td>VS Code + Copilot (agent mode)</td><td>The squad dispatches subagents.</td><td>—</td></tr>
+          <tr><td>uv (or Python) + Graphviz <small>(optional)</small></td><td>Only for committed Azure-icon architecture diagrams via the <code>python-diagrams</code> skill; the squad falls back to Mermaid without them.</td><td><code>dot -V</code></td></tr>
+        </tbody>
+      </table>
+
+      <div class="callout">
+        <p>
+          <strong>The Azure MCP is optional.</strong> The Deployer precheck, As-Built Author, and
+          Azure Diagnose all use the <code>azure-resource</code> capability, which prefers
+          <code>@azure/mcp</code> when configured and falls back to the <code>az</code> CLI and the
+          Azure Resource Graph REST API automatically. A missing MCP never blocks the squad — call
+          that out as MCP-optional by design.
+        </p>
+      </div>
+
+      <h3>Wiring the Azure MCP (optional)</h3>
+      <p>
+        The package never writes your <code>.vscode/mcp.json</code> on install, and a normal squad
+        request will not silently create it either. You get it one of two ways:
+      </p>
+      <ol>
+        <li>
+          <strong>Ask the coordinator to scaffold it</strong> (opt-in merge, shown as a diff before it
+          commits): <code>/squad request="merge the squad MCP template into my workspace"</code>.
+        </li>
+        <li>
+          <strong>Create it by hand</strong> — the minimal runnable version is just the official
+          server:
+          <pre><code>{
+  "servers": {
+    "azure": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "@azure/mcp@latest", "server", "start"]
+    }
+  }
+}</code></pre>
+          Reload VS Code, then confirm it is live: ask Copilot to list your resource groups.
+        </li>
+      </ol>
+      <p>
+        The scaffold is a <em>merge</em>, never an overwrite, so any servers you already have are
+        preserved. The pricing block in <code>mcp.template.json</code> is a tracked placeholder, not
+        runnable — only the <code>@azure/mcp</code> server above is demo-ready.
+      </p>
+
+      <h3 id="icon-diagrams">Optional — Azure-icon architecture diagrams</h3>
+      <p>
+        By default the Azure Architect renders the HLD as Mermaid. When you want a committed
+        <strong>icon</strong> diagram (PNG/SVG with real Azure product icons) instead, the architect
+        uses the <code>python-diagrams</code> skill, which renders with the Python
+        <code>diagrams</code> library on a Graphviz backend. It is opt-in and needs two local tools:
+      </p>
+      <ul>
+        <li><strong>uv (or Python)</strong> — runs the generator: <code>winget install astral-sh.uv</code>.</li>
+        <li><strong>Graphviz</strong> — the rendering backend, a system binary: <code>winget install Graphviz.Graphviz</code> (run elevated, then reopen the shell so <code>dot</code> is on PATH).</li>
+      </ul>
+      <p>
+        Both are pure pre-deploy tooling — no Azure login, no spend. On a clean machine the implement
+        stage pauses to install Graphviz (it needs elevation), so pre-install it for a smooth run. To
+        trigger it, add one clause to the design request — you name the <em>outcome</em>, not the
+        resources, and the architect derives the diagram from its own design and the Bicep, committing
+        paired PNG + SVG under <code>docs/architecture/</code>:
+      </p>
+      <pre><code>/squad request="... Also render the architecture you decide on as committed Azure-icon diagram images using the python-diagrams skill."</code></pre>
+      <p>Without these tools the architect simply falls back to Mermaid; nothing breaks.</p>
+
+      <h2>Beat 0 — Initialize the squad</h2>
+      <pre><code>/squad profile=azure request="Set up the squad for an Azure infrastructure project."</code></pre>
+      <p>
+        The coordinator discovers the repo, proposes the <code>azure</code> profile, and on your
+        confirmation seeds the squad. <strong>Narrate:</strong> "One cast — Cost Manager, Architect,
+        IaC Author, Deployer, As-Built, and Diagnose — and riding along with them the
+        <em>methodology spine</em>: researcher, lead, developer, tester, so research → plan →
+        implement → review is always available."
+      </p>
+
+      <h2>Beat 1 — Cost analysis</h2>
+      <pre><code>/squad request="Estimate the monthly Azure cost for a small internal web workload in West Europe: a frontend and a backend App Service, an Azure SQL Database, a Key Vault, and a Storage account, reached over private endpoints on a VNet. I need the monthly cost to stay under $60 — give an indicative figure and WAF cost-optimization recommendations to hit that target."</code></pre>
+      <p>
+        The Cost Manager produces an indicative estimate via the pricing path (MCP if wired, REST
+        fallback otherwise) plus the WAF Cost Optimization checklist.
+      </p>
+
+      <h2>Beat 2 — Architecture, then IaC</h2>
+      <pre><code>/squad request="Design the HLD and LLD for that workload — frontend and backend web apps, Azure SQL, Key Vault, and Storage in West Europe — using Azure Verified Modules and a landing-zone-aligned layout. Configure the VNet and subnets, add private endpoints and private links where needed, follow security standards, and decide whether containerization is worth it."</code></pre>
+      <pre><code>/squad request="Author the Bicep for that LLD under infra/bicep/demo using AVM modules. Do not deploy."</code></pre>
+      <p>
+        The Azure Architect emits the Mermaid HLD and the Bicep-friendly LLD table.
+        <strong>This is where the methodology surfaces:</strong> "author the Bicep" is an
+        implementation-tier request, so the Implementation Gate runs <strong>Task Researcher</strong>
+        (AVM modules, landing-zone) then <strong>Task Planner</strong> (the IaC plan) <em>before</em>
+        the IaC Author writes a line. It never implements cold.
+      </p>
+      <p>
+        Want committed <strong>Azure-icon</strong> diagrams instead of Mermaid? Add
+        <em>"render it as Azure-icon diagram images using the python-diagrams skill"</em> to the design
+        request — see <a href="#icon-diagrams">Optional — Azure-icon architecture diagrams</a> above for
+        the one-time <code>uv</code> + Graphviz setup.
+      </p>
+
+      <h2>Beat 2b — Review the implementation <small>(new in 0.8.1)</small></h2>
+      <p>
+        After the IaC Author lands the Bicep, <strong>Review Follow-Through</strong> dispatches
+        <code>tester</code> (Implementation Validator or Code Review Full) to check the IaC against
+        the LLD. Review now closes every implementation, making the gate symmetric — research and
+        plan precede the build, review follows it. You can also request it explicitly:
+      </p>
+      <pre><code>/squad request="Review the Bicep we just authored against the LLD and flag any drift."</code></pre>
+
+      <h2>Beat 3 — Governance discovery + gated deploy</h2>
+      <pre><code>/squad request="Deploy infra/bicep/demo to my subscription. Run the policy precheck first and show me what governance constraints apply before the gate."</code></pre>
+      <p>
+        The Deployer runs a <strong>read-only Azure Policy precheck</strong> (effective assignments
+        and predicted denials) <em>before</em> the Impactful-Action Gate, then stops for your
+        approval. <strong>Narrate:</strong> "It discovers real subscription policy before asking to
+        deploy — and never deploys without me." For a safe demo, decline at the gate; the precheck
+        value is already shown.
+      </p>
+
+      <h2>Beat 4 — As-built documentation</h2>
+      <p>Point at an <strong>existing</strong> resource group so it works with no deploy:</p>
+      <pre><code>/squad request="Document the deployed Azure infrastructure in resource group rg-demo as as-built artifacts: a resource inventory, a compliance matrix from Azure Policy, an operations runbook, and a backup/DR plan."</code></pre>
+      <p>
+        The As-Built Author inventories via Resource Graph (read-only), builds the compliance matrix,
+        and drafts the runbook and DR plan for Doc Ops — delivered as a markdown package.
+      </p>
+
+      <h2>Beat 5 — Diagnose</h2>
+      <pre><code>/squad request="Diagnose why the App Service in resource group rg-demo is returning 5xx errors. Query Resource Health and recent logs, rank the likely causes, and recommend fixes — but do not change anything."</code></pre>
+      <p>
+        The Azure Diagnose role queries Resource Health, Azure Monitor (KQL), and Resource Graph,
+        returns ranked hypotheses with evidence, and hands any fix to the gated Deployer or the IaC
+        Author — strictly read-only.
+      </p>
+
+      <h2>The autonomous one-request version</h2>
+      <p>
+        The same arc runs from a single autopilot request that expresses the <em>need</em> and names
+        no steps. The squad derives the sequence itself:
+      </p>
+      <pre><code>/squad mode=autopilot profile=azure request="Stand up a small, production-ready web app on Azure for an internal team — web apps for a frontend and a backend with a SQL database, secrets handling, and file storage in West Europe, I need you to configure vnets and subnets for that and decide on the resources that you prefer. Make sure to follow security standards and create private endpoints and private links when needed. I need monthly cost to stay under $60, the setup to respect our governance, and to be able to operate and troubleshoot it once it's live. So you are free to decide whether it is better to do containerization or not. Keep me in control of anything that spends money or changes my subscription. Also render the architecture you decide on as committed Azure-icon diagram images."</code></pre>
+      <p>From that one line, autopilot sequences the pipeline and stops only where it must:</p>
+      <ul>
+        <li><strong>Init</strong> — proposes the <code>azure</code> profile and waits for your confirmation.</li>
+        <li><strong>Research → Plan</strong> — Task Researcher then Task Planner.</li>
+        <li><strong>Council</strong> — architect, security, and cost weigh in before any build.</li>
+        <li><strong>Implement</strong> — Azure Architect and IaC Author produce the design and the Bicep.</li>
+        <li><strong>Review</strong> — <code>tester</code> validates the implementation.</li>
+        <li><strong>Impactful-Action Gate</strong> — stops before the deploy and asks for approval.</li>
+        <li><strong>As-built + final-outcome validation</strong> — documents the result and waits for your sign-off.</li>
+      </ul>
+      <p>
+        You only touch it at the profile confirm, the deploy gate, and the final sign-off — that is
+        the "tell it once, let it run" mode.
+      </p>
+
+      <div class="callout warn">
+        <p>
+          <strong>Diagnose needs a symptom.</strong> On a clean deploy there is nothing failing, so
+          the autonomous run naturally covers cost → architecture → IaC → review → gated deploy →
+          as-built, but <em>not</em> a live diagnosis. Keep Beat 5 as a separate reactive request when
+          you want to show it — folding a fake failure into the autonomous request would feel staged.
+        </p>
+      </div>
+
+      <h2>Failure-safe fallbacks</h2>
+      <table>
+        <thead>
+          <tr><th>If…</th><th>Then…</th></tr>
+        </thead>
+        <tbody>
+          <tr><td><code>@azure/mcp</code> will not load</td><td>The squad falls back to the <code>az</code> CLI / Retail Prices REST automatically — call it out as MCP-optional design.</td></tr>
+          <tr><td>No spare subscription to deploy</td><td>Stop Beat 3 at the gate; run Beats 4 and 5 against an existing resource group.</td></tr>
+          <tr><td>A role does not dispatch</td><td>Confirm <code>v0.8.1</code> is installed — the as-built, diagnose, and modernization roles entered the coordinator's dispatch list in <code>0.8.1</code>.</td></tr>
+          <tr><td>Deep pricing (RI / spot / PTU) asked</td><td>The community pricing MCP is opt-in; the Retail Prices REST fallback covers retail pricing today.</td></tr>
+        </tbody>
+      </table>
+
+      <h2>Closing talking points</h2>
+      <ul>
+        <li><strong>No clone.</strong> hve-squad is <code>apm install</code> into <em>your</em> repo — the squad rides along.</li>
+        <li><strong>MCP-optional.</strong> Every Azure capability has a named non-MCP fallback, so a missing server never blocks the squad.</li>
+        <li><strong>Safe by construction.</strong> Deploys stay behind the Impactful-Action Gate; as-built and diagnose are strictly read-only.</li>
+        <li><strong>Full methodology.</strong> Research → plan → implement → review runs in every profile, so the Azure work is planned and reviewed, not improvised.</li>
+      </ul>
+
+      <div class="pager">
+        <a class="prev" href="usage.html">
+          <div class="dir">← Back</div>
+          <div class="ttl">Usage</div>
+        </a>
+        <a class="next" href="maintaining.html">
+          <div class="dir">Next →</div>
+          <div class="ttl">Maintaining</div>
+        </a>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        hve-squad · built on <a href="https://github.com/microsoft/hve-core">Microsoft HVE Core</a>
+        agents and conventions · <a href="https://github.com/Peter-N91/hve-squad">Source on GitHub</a>
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -16,6 +16,7 @@
         <a href="index.html">Home</a>
         <a href="getting-started.html" class="active">Getting Started</a>
         <a href="usage.html">Usage</a>
+        <a href="demo.html">Demo</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -16,6 +16,7 @@
         <a href="index.html" class="active">Home</a>
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
+        <a href="demo.html">Demo</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>
@@ -58,6 +59,12 @@
             <h3>Run the Squad</h3>
             <p>Profiles, autonomy modes, remote approval, and how the coordinator routes work.</p>
             <span class="tag">Consumer</span>
+          </a>
+          <a class="card" href="demo.html">
+            <div class="icon">🎬</div>
+            <h3>Demo</h3>
+            <p>A runnable Azure walkthrough — cost, architecture, IaC, gated deploy, as-built, and diagnose — plus the autonomous one-request version.</p>
+            <span class="tag">Walkthrough</span>
           </a>
           <a class="card" href="maintaining.html">
             <div class="icon">🔧</div>

--- a/docs/maintaining.html
+++ b/docs/maintaining.html
@@ -16,6 +16,7 @@
         <a href="index.html">Home</a>
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
+        <a href="demo.html">Demo</a>
         <a href="maintaining.html" class="active">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>
@@ -212,9 +213,9 @@ git push origin vX.Y.Z</code></pre>
       </p>
 
       <div class="pager">
-        <a class="prev" href="usage.html">
+        <a class="prev" href="demo.html">
           <div class="dir">← Back</div>
-          <div class="ttl">Usage</div>
+          <div class="ttl">Demo</div>
         </a>
         <a class="next" href="troubleshooting.html">
           <div class="dir">Next →</div>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -16,6 +16,7 @@
         <a href="index.html">Home</a>
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
+        <a href="demo.html">Demo</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html" class="active">Troubleshooting</a>
         <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -16,6 +16,7 @@
         <a href="index.html">Home</a>
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html" class="active">Usage</a>
+        <a href="demo.html">Demo</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>
@@ -241,9 +242,9 @@
           <div class="dir">← Back</div>
           <div class="ttl">Getting Started</div>
         </a>
-        <a class="next" href="maintaining.html">
+        <a class="next" href="demo.html">
           <div class="dir">Next →</div>
-          <div class="ttl">Maintaining</div>
+          <div class="ttl">Demo</div>
         </a>
       </div>
     </div>

--- a/squad-src/.github/agents/squad/squad-azure-architect.agent.md
+++ b/squad-src/.github/agents/squad/squad-azure-architect.agent.md
@@ -21,6 +21,7 @@ Author Azure high-level and low-level designs for a target workload. The charter
 Three references govern how this charter operates. Read them on first use of a turn and honor them throughout.
 
 * `.github/instructions/squad/squad-mcp-capability.instructions.md` defines the capability-aware MCP preference and the Mermaid fallback contract.
+* `.github/skills/python-diagrams/` provides the file-based, Azure-icon diagram template (Python `diagrams` library) used when a committed PNG/SVG image is preferred over Mermaid for an HLD or LLD.
 * Azure Verified Modules catalog at <https://aka.ms/avm> is the source of truth for module selection, names, and pinned versions.
 * Azure landing zones reference architecture at <https://aka.ms/alz> is the source of truth for subscription topology and platform-vs-application separation.
 * `.github/instructions/coding-standards/bicep/bicep.instructions.md` informs the shape of the LLD so a `developer` can convert it directly to Bicep. This charter does not author Bicep.
@@ -62,7 +63,7 @@ The HLD is a Mermaid `graph TD` or `flowchart LR` diagram that frames the worklo
 2. Include the network topology: hub and spokes, VNets, subnets, private endpoints, peering, ingress and egress paths.
 3. Include the identity perimeter: Entra ID tenants, managed identities, role-assignment scopes, federation boundaries.
 4. Include data flows between major components, with crossings of trust boundaries called out explicitly.
-5. Prefer a diagram-rendering MCP when one is available per `.github/instructions/squad/squad-mcp-capability.instructions.md`. Fall back to Mermaid (always available in Copilot chat) when no MCP is present.
+5. Render per the `diagram-rendering` ladder in `.github/instructions/squad/squad-mcp-capability.instructions.md`: prefer a draw.io MCP when configured; when a committed icon image is wanted (HLD or LLD with Azure product icons), use the `python-diagrams` skill (`.github/skills/python-diagrams/`) to emit paired PNG + SVG into `docs/architecture/`; otherwise fall back to Mermaid (always available in Copilot chat).
 
 ### Step 4: Author the LLD as a Bicep-Friendly Resource Table
 

--- a/squad-src/.github/instructions/squad/squad-mcp-capability.instructions.md
+++ b/squad-src/.github/instructions/squad/squad-mcp-capability.instructions.md
@@ -17,7 +17,7 @@ The coordinator passes a capability hint to each dispatched role when the role n
 |--------------------|----------------------------------------------|---------------------------------------------------------------------------------|
 | diagram-rendering  | A draw.io MCP server when one is configured  | Render Mermaid in chat; or author Mermaid in repository markdown                |
 | ADO query          | `@azure-devops/mcp` (Microsoft official)     | Researcher Subagent against the Azure DevOps REST API with a user-supplied PAT  |
-| Azure-pricing      | `msftnadavbh/AzurePricingMCP` community server (or the APEX `jonathan-vella/apex-accelerator` fork) | Researcher Subagent against the Azure Retail Prices REST API (`https://prices.azure.com/api/retail/prices`) |
+| Azure-pricing      | `msftnadavbh/AzurePricingMCP` community server | Researcher Subagent against the Azure Retail Prices REST API (`https://prices.azure.com/api/retail/prices`) |
 | azure-resource     | `@azure/mcp` (official Azure MCP server)      | Researcher Subagent against the Azure CLI (`az`) and the Azure Resource Graph / Resource Manager REST APIs using the user's `az login` context |
 | architecture-docs  | `microsoft-docs` MCP when configured         | Researcher Subagent against `learn.microsoft.com` via web fetch                 |
 | code-context       | `context7` MCP when configured               | Researcher Subagent against the published library documentation                 |

--- a/squad-src/.github/skills/azure-scaffold/SKILL.md
+++ b/squad-src/.github/skills/azure-scaffold/SKILL.md
@@ -14,7 +14,7 @@ metadata:
 
 This skill bundles the **documentation-only reference templates** a consumer repository needs to do
 Azure work end-to-end — author Infrastructure-as-Code, deploy to Azure, and govern infrastructure —
-the way a deployable template repo (such as the APEX accelerator) ships them. Because hve-squad is an
+the way a deployable template repo ships them. Because hve-squad is an
 APM **package** (installed *into* a repo) rather than a template repo (cloned *as* a repo), it cannot
 ship live pipelines. Instead it ships these templates and a consumer-facing agent copies them into the
 consumer's repo on demand.

--- a/squad-src/.github/skills/python-diagrams/SKILL.md
+++ b/squad-src/.github/skills/python-diagrams/SKILL.md
@@ -1,0 +1,101 @@
+---
+name: python-diagrams
+description: 'Documentation-only reference template for rendering Azure architecture diagrams with real product icons using the Python `diagrams` library (Graphviz backend), producing paired PNG + SVG output. Use when a squad role needs a committed, file-based icon diagram (HLD/LLD) instead of Mermaid, especially for the Squad Azure Architect. Templates never run from this package; a consumer copies them on demand.'
+license: MIT
+metadata:
+  authors: "Peter-N91/hve-squad"
+  spec_version: "1.0"
+  last_updated: "2026-06-19"
+---
+
+# Python Diagrams
+
+## Overview
+
+This skill bundles a **documentation-only reference template** for rendering Azure architecture
+diagrams with real Azure product icons using the Python [`diagrams`](https://diagrams.mingrammer.com/)
+library on a Graphviz backend. It is the **file-based, committed-artifact** counterpart to the squad's
+Mermaid default and the interactive `drawio` MCP path: where Mermaid renders inline and draw.io opens
+an editor, this skill writes paired `.png` + `.svg` siblings straight into the consumer repo.
+
+Like every other reference template in the squad package (see `.github/skills/azure-scaffold/` and
+`.github/skills/squad/`), **nothing here runs from the package**. The consumer copies a generator into
+their repo, adjusts it to match their Bicep or Terraform modules, and runs it. The package never reads
+or writes the consumer's source tree.
+
+This skill backs the `diagram-rendering` capability's non-MCP, file-output option documented in
+[`squad-mcp-capability.instructions.md`](../../instructions/squad/squad-mcp-capability.instructions.md)
+(*"Out-of-Band Fallbacks → Python `diagrams` Library"*). The library is the integration surface; no
+`.vscode/mcp.json` entry is required.
+
+## When to use
+
+* A role (typically the **Squad Azure Architect**) needs an HLD or LLD diagram with **Azure icons**
+  persisted as a committed image, not an inline Mermaid block or a browser-only draw.io tab.
+* You want the diagram to live next to the IaC and stay diffable in version control.
+
+Does **not**: produce Mermaid (author that inline), drive the `drawio` MCP (that is the interactive
+draw.io path), generate Bicep/Terraform, or deploy anything.
+
+## Bundled files
+
+| File                                                       | Consumer destination (suggested)                       | Purpose                                                                 |
+|------------------------------------------------------------|--------------------------------------------------------|-------------------------------------------------------------------------|
+| [requirements.txt](requirements.txt)                       | merged into the repo's Python deps                     | Pins `diagrams` and `graphviz`; notes the Graphviz system prerequisite. |
+| [scripts/diagram_io.py](scripts/diagram_io.py)             | beside each generator (or on `sys.path`)               | Shared output helper enforcing the paired PNG + SVG dual-output contract. |
+| [scripts/verify_installation.py](scripts/verify_installation.py) | run once after install                            | Confirms `diagrams` imports and Graphviz `dot` renders.                 |
+| [templates/azure-webapp-lld.py](templates/azure-webapp-lld.py)  | `docs/architecture/azure_webapp_lld.py`           | Azure internal web app LLD generator with real Azure icons.             |
+
+## Prerequisites
+
+1. **Graphviz** (system binary, not pip-installable) on PATH:
+   * Windows: `winget install Graphviz.Graphviz` (machine-scope; run elevated, then reopen the shell)
+   * macOS: `brew install graphviz`
+   * Linux: `apt-get install graphviz`
+2. **Python packages**: `pip install -r requirements.txt` (or `uv run --with diagrams ...`).
+
+Verify both with `python scripts/verify_installation.py`.
+
+## Usage
+
+1. Copy `scripts/diagram_io.py` and a generator from `templates/` into the consumer repo (for an LLD,
+   copy `templates/azure-webapp-lld.py` next to `diagram_io.py` under `docs/architecture/`).
+2. Edit the generator's nodes and edges to match the project's actual Bicep or Terraform modules.
+3. Run it: `python azure-webapp-lld.py` (or `uv run --with diagrams python azure-webapp-lld.py`).
+4. Commit the emitted `azure-webapp-lld.png` and `.svg`.
+
+## Dual-output contract
+
+Every generator imports `diagram_kwargs` from `diagram_io` instead of setting `outformat` inline, so
+all diagrams render **both** a PNG and an SVG sibling with consistent naming. This keeps a
+review-friendly raster (PNG) and a scalable vector (SVG) in sync from a single source of truth.
+
+```python
+from diagrams import Diagram
+from diagram_io import diagram_kwargs
+
+with Diagram("My architecture", **diagram_kwargs("01-architecture", direction="LR")):
+    ...  # nodes and edges
+```
+
+## Azure node reference
+
+Import the specific node class per resource; common Azure nodes used by the web app template:
+
+```python
+from diagrams.azure.compute import AppServices
+from diagrams.azure.database import SQLDatabases
+from diagrams.azure.network import VirtualNetworks, PrivateEndpoint, Subnets
+from diagrams.azure.security import KeyVaults
+from diagrams.azure.storage import StorageAccounts
+from diagrams.azure.analytics import LogAnalyticsWorkspaces
+from diagrams.azure.identity import ManagedIdentities
+```
+
+The full Azure node catalog is at <https://diagrams.mingrammer.com/docs/nodes/azure>.
+
+## Fallback ladder
+
+Per the capability map, the `diagram-rendering` order is: a draw.io MCP when configured → this Python
+`diagrams` library for committed image output → Mermaid in chat or repository markdown when neither is
+available. A role never blocks on a missing tool; it falls back and records which path it took.

--- a/squad-src/.github/skills/python-diagrams/requirements.txt
+++ b/squad-src/.github/skills/python-diagrams/requirements.txt
@@ -1,0 +1,11 @@
+# python-diagrams skill runtime dependencies.
+#
+# System prerequisite (NOT pip-installable): Graphviz must be on PATH.
+#   Windows:  winget install Graphviz.Graphviz
+#   macOS:    brew install graphviz
+#   Linux:    apt-get install graphviz
+#
+# Install the Python packages with:
+#   pip install -r requirements.txt
+diagrams>=0.23.4
+graphviz>=0.20.3

--- a/squad-src/.github/skills/python-diagrams/scripts/diagram_io.py
+++ b/squad-src/.github/skills/python-diagrams/scripts/diagram_io.py
@@ -1,0 +1,55 @@
+"""Shared output helpers for the python-diagrams skill.
+
+Every diagram generator imports from this module instead of configuring
+output formats inline, so all artifacts follow the same dual-output
+contract: each diagram is rendered as a paired PNG and SVG sibling. This
+mirrors the reference-template-in-a-skill pattern used elsewhere in the
+squad package and keeps rendered evidence diffable and review-friendly.
+
+Usage::
+
+    from diagrams import Diagram
+    from diagram_io import diagram_kwargs
+
+    with Diagram("My architecture", **diagram_kwargs("01-architecture", direction="LR")):
+        ...  # nodes and edges
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+# Formats every generator emits, in render order.
+DUAL_OUTPUT_FORMATS: list[str] = ["png", "svg"]
+
+
+def diagram_kwargs(
+    base_name: str,
+    *,
+    direction: str = "LR",
+    outdir: str | Path = ".",
+    show: bool = False,
+) -> dict[str, Any]:
+    """Build keyword arguments for :class:`diagrams.Diagram`.
+
+    Args:
+        base_name: File stem for the rendered diagram, without an extension.
+        direction: Graph layout direction (``"LR"``, ``"TB"``, ``"RL"``, ``"BT"``).
+        outdir: Directory the paired PNG and SVG siblings are written to;
+            created if it does not exist.
+        show: Whether to open the rendered diagram after generation. Defaults
+            to ``False`` so generators stay headless and CI-safe.
+
+    Returns:
+        A mapping suitable for ``Diagram(title, **diagram_kwargs(...))`` that
+        renders paired PNG and SVG output into ``outdir``.
+    """
+    out = Path(outdir)
+    out.mkdir(parents=True, exist_ok=True)
+    return {
+        "filename": str(out / base_name),
+        "outformat": list(DUAL_OUTPUT_FORMATS),
+        "show": show,
+        "direction": direction,
+    }

--- a/squad-src/.github/skills/python-diagrams/scripts/verify_installation.py
+++ b/squad-src/.github/skills/python-diagrams/scripts/verify_installation.py
@@ -1,0 +1,50 @@
+"""Verify the python-diagrams toolchain is installed and rendering.
+
+Checks two things the skill depends on:
+
+1. The Python ``diagrams`` package (and its Azure node set) imports.
+2. Graphviz's ``dot`` binary is on PATH and can render a trivial diagram.
+
+Run::
+
+    python verify_installation.py
+
+Exits ``0`` when both checks pass, ``1`` otherwise with remediation hints.
+"""
+
+from __future__ import annotations
+
+import sys
+import tempfile
+from pathlib import Path
+
+
+def main() -> int:
+    """Run the import and render checks; return a process exit code."""
+    try:
+        from diagrams import Diagram
+        from diagrams.azure.compute import AppServices
+    except ImportError as exc:
+        print(f"FAIL: python 'diagrams' package not importable: {exc}")
+        print("Fix: pip install -r requirements.txt")
+        return 1
+
+    try:
+        with tempfile.TemporaryDirectory() as tmp:
+            out = Path(tmp) / "verify"
+            with Diagram("verify", filename=str(out), outformat="png", show=False):
+                AppServices("probe")
+            if not out.with_suffix(".png").exists():
+                print("FAIL: render produced no PNG (is Graphviz 'dot' installed?)")
+                return 1
+    except Exception as exc:  # noqa: BLE001 - surface any render failure to the user
+        print(f"FAIL: render failed (Graphviz 'dot' missing or broken?): {exc}")
+        print("Fix: install Graphviz and reopen the shell, e.g. winget install Graphviz.Graphviz")
+        return 1
+
+    print("OK: 'diagrams' imports and Graphviz rendered a test PNG.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/squad-src/.github/skills/python-diagrams/templates/azure-webapp-lld.py
+++ b/squad-src/.github/skills/python-diagrams/templates/azure-webapp-lld.py
@@ -1,0 +1,79 @@
+"""Azure internal web app LLD diagram (reference template).
+
+Renders a low-level design diagram with real Azure icons for an internal
+web app baseline: two App Service apps (frontend + backend), private Azure
+SQL and Storage, Key Vault via managed identity, a VNet with integration
+and private-endpoint subnets, and Log Analytics diagnostics.
+
+This file is a documentation-only reference template. Copy it into a
+consumer repo (for example ``docs/architecture/azure_webapp_lld.py``),
+adjust the nodes and edges to match that project's Bicep or Terraform
+modules, then run it to emit paired PNG + SVG output::
+
+    python azure-webapp-lld.py
+
+Prerequisites:
+    * ``pip install -r requirements.txt`` (the ``diagrams`` package).
+    * Graphviz ``dot`` on PATH (``winget install Graphviz.Graphviz``).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Make the shared diagram_io helper importable whether this file runs from
+# the skill's templates/ folder or from a copy placed beside scripts/.
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+if _SCRIPTS.is_dir():
+    sys.path.insert(0, str(_SCRIPTS))
+else:
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from diagrams import Cluster, Diagram, Edge  # noqa: E402
+from diagrams.azure.analytics import LogAnalyticsWorkspaces  # noqa: E402
+from diagrams.azure.compute import AppServices  # noqa: E402
+from diagrams.azure.database import SQLDatabases  # noqa: E402
+from diagrams.azure.network import PrivateEndpoint, VirtualNetworks  # noqa: E402
+from diagrams.azure.security import KeyVaults  # noqa: E402
+from diagrams.azure.storage import StorageAccounts  # noqa: E402
+from diagrams.onprem.client import Users  # noqa: E402
+
+from diagram_io import diagram_kwargs  # noqa: E402
+
+
+def main() -> None:
+    """Render the LLD diagram into the directory containing this script."""
+    outdir = Path(__file__).resolve().parent
+    with Diagram(
+        "Azure Internal Web App - LLD (West Europe)",
+        **diagram_kwargs("azure-webapp-lld", direction="LR", outdir=outdir),
+    ):
+        user = Users("Internal user")
+        logs = LogAnalyticsWorkspaces("Log Analytics")
+
+        with Cluster("VNet"):
+            with Cluster("Integration subnet"):
+                frontend = AppServices("Frontend App Service\n(Entra ID)")
+                backend = AppServices("Backend App Service\n(Managed identity)")
+            with Cluster("Private-endpoints subnet"):
+                sql_pe = PrivateEndpoint("SQL PE")
+                storage_pe = PrivateEndpoint("Storage PE")
+                kv_pe = PrivateEndpoint("Key Vault PE")
+
+        sql = SQLDatabases("Azure SQL (Basic)")
+        storage = StorageAccounts("Storage")
+        keyvault = KeyVaults("Key Vault")
+
+        user >> Edge(label="HTTPS / Entra ID") >> frontend
+        frontend >> Edge(label="HTTPS") >> backend
+        backend >> Edge(label="Managed identity") >> kv_pe >> keyvault
+        backend >> Edge(label="Private link") >> sql_pe >> sql
+        backend >> Edge(label="Private link") >> storage_pe >> storage
+
+        for node in (frontend, backend, sql, storage, keyvault):
+            node >> Edge(style="dotted", label="diagnostics") >> logs
+
+
+if __name__ == "__main__":
+    main()

--- a/squad-src/.github/skills/squad/mcp.template.json
+++ b/squad-src/.github/skills/squad/mcp.template.json
@@ -115,11 +115,8 @@
       //   Primary:     msftnadavbh/AzurePricingMCP (active; ~18 tools,
       //                including reserved-instance, spot, orphaned-
       //                resource, Databricks, GitHub, and PTU sizing).
-      //   Alternative: the APEX-maintained jonathan-vella/apex-accelerator
-      //                pricing MCP (token-optimized compact output, latest
-      //                Python) for consumers who prefer compact responses.
       //
-      // Packaging caveat: both servers are packaged for Python (pip /
+      // Packaging caveat: this server is packaged for Python (pip /
       // Docker / uvx), NOT npm, so the `npx` form the other entries use
       // does not apply here. The invocation is likely one of the forms
       // below; VERIFY THE EXACT STDIO COMMAND before use. The precise


### PR DESCRIPTION
Add a python-diagrams skill that renders committed Azure-icon HLD/LLD diagrams (paired PNG+SVG via a shared diagram_io helper, with an azure-webapp-lld template and verify script), and wire it into the Squad Azure Architect's diagram-rendering ladder. Add a docs Demo page with a multi-demo chevron selector, the uv+Graphviz prerequisite, and real tested /squad requests. Remove all third-party APEX accelerator references. Bump version to 0.8.4.

<!--
Title convention: release: vX.Y.Z   (for releases)
                  type(scope): short description   (for regular changes)
-->

## Summary

<!-- One or two lines describing what this PR does. -->

## Target version

- Target version: **vX.Y.Z**
- Previous version: vX.Y.Z

## Type of change

- [ ] Release (version bump)
- [ ] Feature / new content
- [ ] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Changelog

- [ ] `CHANGELOG.md` has a `## [X.Y.Z]` section describing this release
- [ ] `apm.yml` `version:` is bumped to match (release PRs only)

## Release checklist (release PRs only)

- [ ] Branch named `release/vX.Y.Z`
- [ ] PR title is `release: vX.Y.Z`
- [ ] After merge, tag the merge commit: `git tag -a vX.Y.Z -m "Release vX.Y.Z"`
- [ ] Push the tag: `git push origin vX.Y.Z`
- [ ] (Optional) Publish a GitHub Release for the tag

## Notes

<!-- Anything reviewers should know: follow-ups, risks, manual steps. -->
