### PR TITLE
fix(squad): seed Azure roles and modernizer in SKILL.md templates

### DIFF
--- a/squad-src/.github/skills/squad/SKILL.md
+++ b/squad-src/.github/skills/squad/SKILL.md
@@ -163,6 +163,11 @@ description: "Squad roster: roles and the deployed HVE Core agents that fill the
 | designer        | Iota        | UX UI Designer               | DT Coach, DT Learning Tutor                            | runSubagent / task | default                 |
 | fact-checker    | Kappa       | Finding Deep Verifier        | —                                                      | runSubagent / task | fast                    |
 | cost-manager    | Lambda      | Squad Cost Manager           | —                                                      | runSubagent / task | default                 |
+| iac-author      | Mu          | Squad IaC Author             | —                                                      | runSubagent / task | default                 |
+| deployer        | Nu          | Squad Deployer               | —                                                      | runSubagent / task | default                 |
+| asbuilt-author  | Xi          | Squad As-Built Author        | —                                                      | runSubagent / task | default                 |
+| azure-diagnose  | Omicron     | Squad Azure Diagnose         | —                                                      | runSubagent / task | fast                    |
+| modernizer      | Pi          | Squad Modernization Planner  | Squad SQL Migration Advisor                            | runSubagent / task | default                 |
 | scribe          |             | Squad Scribe                 | Memory                                                 | runSubagent / task | fast                    |
 | devrel          |             | —                            | —                                                      | —                  | — (thin charter needed) |
 ```
@@ -189,7 +194,14 @@ description: "Squad routing: request patterns mapped to roles, autonomy tiers, a
 | architecture, system design, components    | System Architecture Reviewer | auto          | yes               |
 | responsible AI, RAI, fairness, harm        | RAI Planner                  | confirm       | yes               |
 | verify finding, confirm claim, fact-check  | Finding Deep Verifier        | auto          | yes               |
+| author IaC, write Bicep, write Terraform, convert LLD to infra, infrastructure as code | Squad IaC Author | confirm | no |
+| deploy, provision, what-if, terraform plan, terraform apply, az deployment | Squad Deployer | confirm | no |
+| as-built, resource inventory, compliance matrix, operations runbook, DR plan, document deployed infrastructure | asbuilt-author | confirm | no |
+| diagnose, troubleshoot, resource health, why is resource failing, investigate deployed, policy check | azure-diagnose | auto | yes |
 | validate, cross-check, pre-implementation review, council, design review, go/no-go, implement-and-cost, implement-and-risk | architect, security, cost-manager, product-owner, rai (optional) | confirm | yes |
+| modernize, upgrade framework, migrate, port legacy, .NET upgrade, Java migration, dependency upgrade, containerize | modernizer | confirm | no |
+| sql migration, database migration, schema migration, data migration, sql server to azure, downtime migration plan, cutover strategy | modernizer | confirm | no |
+| re-platform, rewrite, port to, rebuild in, cross-stack rewrite, Node to .NET, React to Angular, convert to another language | modernizer | confirm | no |
 ```
 
 ### decisions.md


### PR DESCRIPTION
## Summary

The `team.md` and `routing.md` seed templates in `squad-src/.github/skills/squad/SKILL.md` are out of sync with the canonical roster and routing conventions. They predate the v0.5.0 Azure execution layer and the v0.8.21 `modernizer` / SQL-migration additions, so they omit:

- `team.md` seed: the `iac-author`, `deployer`, `asbuilt-author`, `azure-diagnose`, and `modernizer` rows.
- `routing.md` seed: the matching routing rows, including `author IaC`, `deploy`, `as-built`, `diagnose`, `modernize`, **`sql migration`**, and `re-platform`.

## Why it matters

The Squad Coordinator stamps these seed templates into `.copilot-tracking/squad/` on first run (Init Mode, Phase 2 Create). On a freshly initialized `azure` or `full` squad, the seeded `team.md` can therefore lack the `modernizer` member and the seeded `routing.md` can lack the `sql migration ... -> modernizer` rule. When that happens, a `/squad` SQL Server-to-Azure migration request does not deterministically route to the **Squad SQL Migration Advisor** (added in v0.8.21): the coordinator finds no matching rule/role and escalates or misroutes.

The individual pieces are already correct: the advisor agent and the `sql-migration-advisor` skill are packaged in `apm.yml`, `squad-routing.instructions.md` has the `sql migration -> modernizer` rule, `squad-roster.instructions.md` maps `modernizer` (Primary `Squad Modernization Planner`, Alternate `Squad SQL Migration Advisor`) and includes `modernizer` in the `azure` and `full` profiles, and the coordinator `agents:` allowlist includes the advisor. Only the SKILL.md seed **templates** were stale.

## Change

Reconciles both seed blocks with `squad-roster.instructions.md` (the `full` profile cast) and `squad-routing.instructions.md` (the default routing rules) for the Azure execution layer and the `modernizer` role. New rows reuse the same agent names, tiers, and parallel-eligible flags as the canonical sources.

## Scope notes

- Product-profile rows (`analyst`, `product-owner`, `presenter`, `technical-writer`, `experimenter` and their routing cues) are intentionally left out of the full-profile seed, since those roles are not part of the `full` profile.
- No CHANGELOG entry or version bump is included; left to the maintainer's release flow.

## Testing

- The `team.md` seed now contains the `modernizer` member with Alternate `Squad SQL Migration Advisor`.
- The `routing.md` seed now contains the `sql migration, database migration, sql server to azure ... -> modernizer` rule.
- Diff is +12 lines, seed tables only; table column counts are unchanged.

Opened as a draft. If you have already addressed this locally, feel free to close.
