### PR TITLE
fix(workflows): splat release prep arguments as a hashtable

### DIFF
--- a/.changes/unreleased/20260804-release-prep-splatting.md
+++ b/.changes/unreleased/20260804-release-prep-splatting.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **The first Release Prep run failed with `Not found: -GitHubOutput`.** The workflow built its arguments as a PowerShell array and splatted it, but array splatting binds *positionally* — so the literal string `-GitHubOutput` landed in the script's first positional parameter, `-ApmFile`, and the existence check threw on a file by that name. The workflow now splats a hashtable, which binds by name (`.github/workflows/release-prep.yml`).

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -91,10 +91,12 @@ jobs:
           INPUT_BUMP: ${{ inputs.bump }}
           INPUT_DRY_RUN: ${{ inputs.dry_run }}
         run: |
-          $prepArgs = @('-GitHubOutput')
-          if ($env:INPUT_VERSION) { $prepArgs += @('-Version', $env:INPUT_VERSION) }
-          elseif ($env:INPUT_BUMP -and $env:INPUT_BUMP -ne 'fragments') { $prepArgs += @('-Bump', $env:INPUT_BUMP) }
-          if ($env:INPUT_DRY_RUN -eq 'true') { $prepArgs += '-DryRun' }
+          # Hashtable, not array: array splatting binds positionally, so '-GitHubOutput'
+          # would land in the first positional parameter instead of setting the switch.
+          $prepArgs = @{ GitHubOutput = $true }
+          if ($env:INPUT_VERSION) { $prepArgs['Version'] = $env:INPUT_VERSION }
+          elseif ($env:INPUT_BUMP -and $env:INPUT_BUMP -ne 'fragments') { $prepArgs['Bump'] = $env:INPUT_BUMP }
+          if ($env:INPUT_DRY_RUN -eq 'true') { $prepArgs['DryRun'] = $true }
           ./scripts/Invoke-ReleasePrep.ps1 @prepArgs
 
       - name: Commit and push


### PR DESCRIPTION
## Summary

The first **Release Prep** run after #51 merged failed at *Assemble release*:

```
Exception: scripts/Invoke-ReleasePrep.ps1:234
 234 |  … (Test-Path -LiteralPath $required)) { throw "Not found: $required" }
     | Not found: -GitHubOutput
```

The workflow built its arguments as a PowerShell **array** and splatted it. Array splatting binds **positionally**, not by name — so the literal string `-GitHubOutput` was passed as the first positional parameter, `-ApmFile`, and the input-existence check threw on a file by that name.

Hashtable splatting binds by name, which is what was intended.

```powershell
# before — '-GitHubOutput' becomes the value of -ApmFile
$prepArgs = @('-GitHubOutput')

# after
$prepArgs = @{ GitHubOutput = $true }
```

## Type of change

- [x] Fix

## Blast radius

Only `release-prep.yml` splatted. The other two callers pass named arguments directly and were never affected — which is why `pr-validation.yml` went green on #51 and why `sync-hve-core.yml` is unaffected.

| Caller | Invocation | Status |
|---|---|---|
| `release-prep.yml` | array splat | **broken, fixed here** |
| `pr-validation.yml` | `-DryRun` direct | fine |
| `sync-hve-core.yml` | `-AllowEmpty -GitHubOutput -ExtraEntry` direct | fine |

## State on `main`

The script threw before writing anything, so nothing is half-applied: `apm.yml` is still `0.11.13`, `CHANGELOG.md` is untouched, and `20260804-change-fragment-release-flow.md` is still pending in `.changes/unreleased/`.

## Verification

All four argument combinations the workflow can produce, run locally against the real repo:

| Case | Result |
|---|---|
| `@{ GitHubOutput = $true }` (the failing case) | `0.11.13 -> 0.11.14 (patch)` |
| `+ Bump = 'minor'` | `0.11.13 -> 0.12.0 (minor)`, override logged |
| `+ Version = '1.2.3'` | `0.11.13 -> 1.2.3 (explicit)` |
| `+ DryRun = $true` | dry run, nothing written |

## Change fragment

- [x] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [x] Its `bump` tracks ideas, not artifacts — `patch`, a defect corrected
- [x] Its body reads as final release notes, not as a commit message
- [x] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

## Notes

Merging this releases **0.11.14** with both pending fragments — the feature from #51 under `### Added` and this fix under `### Fixed`. Confirmed by dry run:

```
Version:   0.11.13 -> 0.11.14 (patch)
Fragments: 2
  patch    Added      20260804-change-fragment-release-flow.md
  patch    Fixed      20260804-release-prep-splatting.md
```

So the end-to-end test #51 was meant to be still happens, one merge later.
