### PR TITLE
Jmservera/security review

### DIFF
--- a/.changes/unreleased/20260806-security-review.md
+++ b/.changes/unreleased/20260806-security-review.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: Security
+---
+
+- Add standard GitHub actions to include regular security reviews

--- a/.changes/unreleased/20260806-security-review.md
+++ b/.changes/unreleased/20260806-security-review.md
@@ -3,4 +3,4 @@ bump: patch
 type: Security
 ---
 
-- Add standard GitHub actions to include regular security reviews
+- **Add automated security scanning workflows.** Introduces Zizmor (GitHub Actions), CodeQL (Python), and Checkov (IaC/secrets) under `.github/workflows/`.

--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -1,0 +1,81 @@
+# Checkov lint
+# Mark "Checkov / Checkov IaC/container scan" as a required check.
+
+name: Checkov IaC scan
+
+on:
+  push:
+    branches:
+      - main
+      - jmservera/security-review
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  checkov:
+    name: Checkov IaC/container scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Install Checkov (pinned)
+        run: python -m pip install checkov==3.2.533
+
+      - name: Run Checkov (blocking, SARIF)
+        # Phase C: blocking. No --soft-fail — a failed check fails the build.
+        # Accepted findings must use a justified inline `# checkov:skip`.
+        run: |
+          checkov \
+            --directory . \
+            --framework github_actions secrets \
+            --skip-path node_modules \
+            --skip-path .venv \
+            --compact \
+            --output cli \
+            --output sarif \
+            --output-file-path console,checkov-results.sarif
+
+      - name: Checkov summary
+        if: always()
+        run: |
+          {
+            echo "### Checkov scan"
+            echo ""
+            echo "See the job log for the full report. This check is blocking (Phase C):"
+            echo "new misconfigurations fail the build; accepted findings carry a"
+            echo "justified inline \`# checkov:skip=<id>:<reason>\`."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload SARIF to GitHub Code Scanning
+        if: always()
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
+        with:
+          sarif_file: checkov-results.sarif
+          category: checkov
+
+      - name: Upload SARIF as artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: checkov-sarif
+          path: checkov-results.sarif
+          retention-days: 30

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -5,7 +5,7 @@ name: "CodeQL Advanced"
 
 on:
   push:
-    branches: ["main"]
+    branches: ["main","jmservera/security-review"]
     paths:
       - '.github/workflows/codeql.yml'
       - '**/*.py'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,53 @@
+# CodeQL analysis. The repo is mostly PowerShell (unsupported by CodeQL) and
+# HTML; the only Python is skill templates under
+# squad-src/.github/skills/python-diagrams/, so this scans Python only.
+name: "CodeQL Advanced"
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - '.github/workflows/codeql.yml'
+      - '**/*.py'
+  pull_request:
+    branches: ["main"]
+    paths:
+      - '.github/workflows/codeql.yml'
+      - '**/*.py'
+  schedule:
+    - cron: '26 3 * * 4'
+
+permissions: {}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload CodeQL results
+      packages: read # fetch internal/private CodeQL packs
+      actions: read
+      contents: read
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -31,7 +31,7 @@ on:
     paths:
       - '.changes/unreleased/**'
   workflow_dispatch:
-    # checkov:skip=CKV_GHA_7:Maintainer-only manual dispatch; inputs are passed through env, never interpolated into shell.
+    # checkov:skip=CKV_GHA_7:Manual dispatch (write access required); inputs are passed through env and never interpolated into the pwsh script body.
     inputs:
       bump:
         description: 'Release level. "fragments" honours what the pending fragments requested; pick minor only when this batch is a genuinely new idea.'

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -31,6 +31,7 @@ on:
     paths:
       - '.changes/unreleased/**'
   workflow_dispatch:
+    # checkov:skip=CKV_GHA_7:Maintainer-only manual dispatch; inputs are passed through env, never interpolated into shell.
     inputs:
       bump:
         description: 'Release level. "fragments" honours what the pending fragments requested; pick minor only when this batch is a genuinely new idea.'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,7 @@ name: Release
 #                       to already contain an entry for that version.
 on:
   workflow_dispatch:
+    # checkov:skip=CKV_GHA_7:Maintainer-only manual release; the version override is validated as semver before use.
     inputs:
       version:
         description: 'Optional: override version in apm.yml (e.g. 0.9.0). Leave blank to release the version already in apm.yml.'
@@ -56,8 +57,14 @@ jobs:
         if: github.event_name == 'workflow_dispatch' && inputs.version != ''
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
-          NEW_VER="${{ inputs.version }}"
+          NEW_VER="$INPUT_VERSION"
+          # Reject anything that isn't a plain semver, so it can't break out of the sed below.
+          if [[ ! "$NEW_VER" =~ ^[0-9]+\.[0-9]+\.[0-9]+([-.+][0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Invalid version override '$NEW_VER'. Expected semver like 1.2.3."
+            exit 1
+          fi
           CURRENT=$(grep '^version:' apm.yml | sed 's/version:[[:space:]]*//')
           if [[ "$CURRENT" == "$NEW_VER" ]]; then
             echo "::notice::apm.yml already at $NEW_VER — no commit needed."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ name: Release
 #                       to already contain an entry for that version.
 on:
   workflow_dispatch:
-    # checkov:skip=CKV_GHA_7:Maintainer-only manual release; the version override is validated as semver before use.
+    # checkov:skip=CKV_GHA_7:Manual release trigger (write access required); the version override is validated as semver before use.
     inputs:
       version:
         description: 'Optional: override version in apm.yml (e.g. 0.9.0). Leave blank to release the version already in apm.yml.'

--- a/.github/workflows/squad-watch.yml
+++ b/.github/workflows/squad-watch.yml
@@ -72,7 +72,7 @@ on:
   pull_request:
     types: [labeled]
   workflow_dispatch:
-    # checkov:skip=CKV_GHA_7:Maintainer-only manual test trigger; inputs are used only in the concurrency key and via env.
+    # checkov:skip=CKV_GHA_7:Manual test trigger (write access required); inputs are used only in the concurrency key and passed via env.
     inputs:
       issue_number:
         description: 'Issue number to run autopilot against (for testing the loop by hand)'

--- a/.github/workflows/squad-watch.yml
+++ b/.github/workflows/squad-watch.yml
@@ -72,6 +72,7 @@ on:
   pull_request:
     types: [labeled]
   workflow_dispatch:
+    # checkov:skip=CKV_GHA_7:Maintainer-only manual test trigger; inputs are used only in the concurrency key and via env.
     inputs:
       issue_number:
         description: 'Issue number to run autopilot against (for testing the loop by hand)'

--- a/.github/workflows/squad-watch.yml
+++ b/.github/workflows/squad-watch.yml
@@ -303,6 +303,9 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           fetch-depth: 0
+          # The squad runs with --allow-all-tools on attacker-authored issue content;
+          # keep the token out of .git/config so a prompt-injected run can't read it.
+          persist-credentials: false
           ref: ${{ steps.prep.outputs.kind == 'pull_request' && github.event.pull_request.head.sha || '' }}
 
       - name: Set up Node.js
@@ -353,6 +356,7 @@ jobs:
           BRANCH: ${{ steps.prep.outputs.branch }}
           SUB_SQUAD: ${{ steps.prep.outputs.subSquad }}
           ISSUE: ${{ steps.prep.outputs.target }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
           git add -A
@@ -374,6 +378,8 @@ jobs:
           fi
 
           git commit -m "chore: address #${ISSUE} via squad watch mode"
+          # Checkout no longer persists credentials, so authenticate the push explicitly.
+          git remote set-url origin "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git"
           git push origin "$BRANCH"
 
           BODY="$RUNNER_TEMP/pr-body.md"

--- a/.github/workflows/sync-hve-core.yml
+++ b/.github/workflows/sync-hve-core.yml
@@ -48,7 +48,7 @@ on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
-    # checkov:skip=CKV_GHA_7:Maintainer-only manual dispatch; boolean toggles only, no shell interpolation.
+    # checkov:skip=CKV_GHA_7:Manual dispatch (write access required); inputs are typed boolean and only compared as strings.
     inputs:
       force:
         description: 'Force update even if hve-core SHA is already current'

--- a/.github/workflows/sync-hve-core.yml
+++ b/.github/workflows/sync-hve-core.yml
@@ -48,6 +48,7 @@ on:
   schedule:
     - cron: '0 6 * * *'
   workflow_dispatch:
+    # checkov:skip=CKV_GHA_7:Maintainer-only manual dispatch; boolean toggles only, no shell interpolation.
     inputs:
       force:
         description: 'Force update even if hve-core SHA is already current'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -2,7 +2,7 @@ name: Zizmor Actions Security Scan
 on:
   workflow_dispatch:
   push:
-    branches: ["dev", "main"]
+    branches: ["dev", "main", "jmservera/security-review"]
     paths:
       - ".github/workflows/**"
   pull_request:

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,47 @@
+name: Zizmor Actions Security Scan
+on:
+  workflow_dispatch:
+  push:
+    branches: ["dev", "main"]
+    paths:
+      - ".github/workflows/**"
+  pull_request:
+    branches: ["dev", "main"]
+  schedule:
+    - cron: "30 4 * * 1"
+permissions: {}
+
+concurrency:
+  group: zizmor-${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Zizmor Actions Analysis
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read # to checkout code
+      actions: read # to read workflow run status
+      security-events: write # to upload SARIF results to security tab
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Install zizmor
+        uses: astral-sh/setup-uv@5a095e7a2014a4212f075830d4f7277575a9d098 # v7.3.1
+        with:
+          enable-cache: false
+
+      - name: Run zizmor (SARIF)
+        run: uvx zizmor --format sarif .github/workflows/ > results.sarif || true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Upload SARIF file
+        if: (!cancelled())
+        uses: github/codeql-action/upload-sarif@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4.31.4
+        with:
+          sarif_file: ${{ github.workspace }}/results.sarif
+          category: zizmor-scan


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -- GitHub PR templates are injected verbatim into the PR description, so they cannot start with a top-level heading or YAML frontmatter. -->
<!--
Title convention: type(scope): short description
-->

## Summary

<!-- One or two lines describing what this PR does. -->

## Type of change

- [ ] Feature / new content
- [ ] Fix
- [ ] Docs only
- [x] Chore / maintenance

## Change fragment

<!--
Do NOT edit CHANGELOG.md and do NOT bump `version:` in apm.yml. Both are
release outputs assembled on main, and editing them here is exactly what makes
concurrent pull requests conflict. CI rejects a PR that touches either.

Run `apm run change` to create your fragment. See .changes/README.md.
-->

- [x] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [x] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [x] Its body reads as final release notes, not as a commit message
- [x] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

<!--
A new agent, skill, or role that extends something already shipping is a patch,
however many files it adds. Minor is for the concept, not for the artifacts
built under it. When unsure, pick patch.

No consumer-visible change at all? Ask a maintainer for the `skip-changelog`
label instead. That skips the version bump too.
-->

## Shared learning sanitization (if proposing a learning)

<!-- Complete only if this PR adds or edits squad-src/.github/skills/squad/learnings/shared-learnings.md. -->

- [x] Remove all secrets, tokens, credentials, and connection strings.
- [x] Remove customer, organization, and individual names.
- [x] Remove repository-specific absolute paths and internal URLs.
- [x] Generalize stack-specific or environment-specific details so the learning applies beyond its origin.
- [x] Confirm the learning is broadly applicable across consumers and scenarios.

## Notes

<!-- Anything reviewers should know: follow-ups, risks, manual steps. -->


This pull request introduces automated security scanning workflows to the repository by adding three new GitHub Actions: Zizmor for workflow analysis, CodeQL for Python code, and Checkov for infrastructure-as-code (IaC) and secrets scanning. It also improves workflow security and compliance by adding justifications for manual triggers, enforcing credential handling best practices, and validating release inputs.

**Automated Security Scanning Workflows:**

* Added `.github/workflows/zizmor.yml` to run Zizmor for security analysis of GitHub Actions workflows, uploading SARIF results to GitHub’s security tab.
* Added `.github/workflows/codeql.yml` to enable CodeQL scanning for Python files, running on pushes, pull requests, and a scheduled basis, with results uploaded for security review.
* Added `.github/workflows/checkov.yml` to run Checkov for IaC and secrets scanning, configured as a blocking check with SARIF uploads and artifact retention.
* Documented the addition of these automated security scans in `.changes/unreleased/20260806-security-review.md`.

**Workflow Security and Compliance Improvements:**

* Added `# checkov:skip` justifications to all manual workflow dispatch triggers (e.g., in `release.yml`, `release-prep.yml`, `squad-watch.yml`, and `sync-hve-core.yml`) to document why these are acceptable and compliant with security scanning. [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R12) [[2]](diffhunk://#diff-0722b1375f2b82d0814d6acab64efbb06c23a87477d8cdcbe015dcbb11323050R34) [[3]](diffhunk://#diff-f802abc4b4326f34985956c6a23c07097ac04d94f9f3061b959f5409a6c9ba02R75) [[4]](diffhunk://#diff-a5fbbe67e87ae07e348894ef535b9ac8e5e938f07c76a11fc78533a165747b41R51)
* Improved credential handling in `squad-watch.yml` by disabling persisted credentials during checkout and explicitly setting the remote URL for authenticated pushes, reducing the risk of token exposure. [[1]](diffhunk://#diff-f802abc4b4326f34985956c6a23c07097ac04d94f9f3061b959f5409a6c9ba02R306-R308) [[2]](diffhunk://#diff-f802abc4b4326f34985956c6a23c07097ac04d94f9f3061b959f5409a6c9ba02R359) [[3]](diffhunk://#diff-f802abc4b4326f34985956c6a23c07097ac04d94f9f3061b959f5409a6c9ba02R381-R382)
* Enhanced input validation in `release.yml` to ensure version overrides are valid semantic versions, preventing injection or misconfiguration risks.