### PR TITLE
Jmservera/suppress and fix security issues

### DIFF
--- a/.github/workflows/checkov.yml
+++ b/.github/workflows/checkov.yml
@@ -60,16 +60,50 @@ jobs:
           {
             echo "### Checkov scan"
             echo ""
-            echo "See the job log for the full report. This check is blocking (Phase C):"
+            if [[ -f checkov-results.sarif ]]; then
+              jq -r '
+                [.runs[].results[]] as $all
+                | ($all | map(select((.suppressions // []) | length > 0))) as $suppressed
+                | ($all | map(select((.suppressions // []) | length == 0))) as $open
+                | "| Level | Count |",
+                  "| --- | ---: |",
+                  "| Errors | \($open | map(select(.level == "error")) | length) |",
+                  "| Warnings | \($open | map(select(.level == "warning")) | length) |",
+                  "| Notes | \($open | map(select(.level == "note")) | length) |",
+                  "| Suppressed | \($suppressed | length) |",
+                  "",
+                  (if ($suppressed | length) > 0 then
+                     "<details><summary>Suppressed findings</summary>",
+                     "",
+                     "| Rule | Location | Justification |",
+                     "| --- | --- | --- |",
+                     ($suppressed[] | "| \(.ruleId) | \(.locations[0].physicalLocation.artifactLocation.uri):\(.locations[0].physicalLocation.region.startLine) | \(.suppressions[0].justification | gsub("\\|"; "\\|") | gsub("\\s+"; " ")) |"),
+                     "",
+                     "</details>"
+                   else empty end)
+              ' checkov-results.sarif
+            else
+              echo "Checkov produced no SARIF output — see the job log."
+            fi
+            echo ""
+            echo "See the job log for the full report. This check is blocking:"
             echo "new misconfigurations fail the build; accepted findings carry a"
             echo "justified inline \`# checkov:skip=<id>:<reason>\`."
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Drop suppressed results before upload
+        if: always()
+        # Code scanning ignores the SARIF `suppressions` property, so an inline
+        # `# checkov:skip` would still surface as an open alert. Strip them here.
+        run: |
+          jq '(.runs[].results) |= map(select((.suppressions // []) | length == 0))' \
+            checkov-results.sarif > checkov-code-scanning.sarif
 
       - name: Upload SARIF to GitHub Code Scanning
         if: always()
         uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa  # v4.36.0
         with:
-          sarif_file: checkov-results.sarif
+          sarif_file: checkov-code-scanning.sarif
           category: checkov
 
       - name: Upload SARIF as artifact

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ name: Release
 #                       to already contain an entry for that version.
 on:
   workflow_dispatch:
-    # checkov:skip=CKV_GHA_7:Manual release trigger (write access required); the version override is validated as semver before use.
+    # checkov:skip=CKV_GHA_7:Manual release trigger (write access required); the version override is validated as semver before use.    
     inputs:
       version:
         description: 'Optional: override version in apm.yml (e.g. 0.9.0). Leave blank to release the version already in apm.yml.'

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -39,9 +39,56 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Zizmor summary
+        if: (!cancelled())
+        # zizmor drops `# zizmor: ignore[...]` findings from the SARIF entirely
+        # rather than emitting them as suppressions, so count the comments instead.
+        run: |
+          {
+            echo "### Zizmor scan"
+            echo ""
+            if [[ -s results.sarif ]]; then
+              suppressed=$(grep -rEoh '#[[:space:]]*zizmor:[[:space:]]*ignore\[[a-z0-9,[:space:]-]+\]' .github/workflows | wc -l)
+              jq -r --arg suppressed "$suppressed" '
+                [.runs[].results[]] as $all
+                | "| Level | Count |",
+                  "| --- | ---: |",
+                  "| Errors | \($all | map(select(.level == "error")) | length) |",
+                  "| Warnings | \($all | map(select(.level == "warning")) | length) |",
+                  "| Notes | \($all | map(select(.level == "note")) | length) |",
+                  "| Suppressed | \($suppressed) |",
+                  "",
+                  (if ($all | length) > 0 then
+                     "<details><summary>Findings by rule</summary>",
+                     "",
+                     "| Rule | Severity | Confidence | Count |",
+                     "| --- | --- | --- | ---: |",
+                     ($all | group_by(.ruleId + "/" + (.properties["zizmor/severity"] // "-"))
+                           | sort_by(length) | reverse | .[]
+                           | "| \(.[0].ruleId) | \(.[0].properties["zizmor/severity"] // "-") | \(.[0].properties["zizmor/confidence"] // "-") | \(length) |"),
+                     "",
+                     "</details>"
+                   else "No findings." end)
+              ' results.sarif
+            else
+              echo "Zizmor produced no SARIF output — see the job log."
+            fi
+            echo ""
+            echo "Findings are reported to the Security tab under the \`zizmor-scan\` category."
+            echo "Accepted findings carry an inline \`# zizmor: ignore[<rule>]\` comment."
+          } >> "$GITHUB_STEP_SUMMARY"
+
       - name: Upload SARIF file
         if: (!cancelled())
         uses: github/codeql-action/upload-sarif@e12f0178983d466f2f6028f5cc7a6d786fd97f4b # v4.31.4
         with:
           sarif_file: ${{ github.workspace }}/results.sarif
           category: zizmor-scan
+
+      - name: Upload SARIF as artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
+        with:
+          name: zizmor-sarif
+          path: results.sarif
+          retention-days: 30


### PR DESCRIPTION
<!-- markdownlint-disable-file MD041 -- GitHub PR templates are injected verbatim into the PR description, so they cannot start with a top-level heading or YAML frontmatter. -->
<!--
Title convention: type(scope): short description
-->

## Summary

<!-- One or two lines describing what this PR does. -->

## Type of change

- [ ] Feature / new content
- [ ] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Change fragment

<!--
Do NOT edit CHANGELOG.md and do NOT bump `version:` in apm.yml. Both are
release outputs assembled on main, and editing them here is exactly what makes
concurrent pull requests conflict. CI rejects a PR that touches either.

Run `apm run change` to create your fragment. See .changes/README.md.
-->

- [ ] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [ ] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [ ] Its body reads as final release notes, not as a commit message
- [ ] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

<!--
A new agent, skill, or role that extends something already shipping is a patch,
however many files it adds. Minor is for the concept, not for the artifacts
built under it. When unsure, pick patch.

No consumer-visible change at all? Ask a maintainer for the `skip-changelog`
label instead. That skips the version bump too.
-->

## Shared learning sanitization (if proposing a learning)

<!-- Complete only if this PR adds or edits squad-src/.github/skills/squad/learnings/shared-learnings.md. -->

- [ ] Remove all secrets, tokens, credentials, and connection strings.
- [ ] Remove customer, organization, and individual names.
- [ ] Remove repository-specific absolute paths and internal URLs.
- [ ] Generalize stack-specific or environment-specific details so the learning applies beyond its origin.
- [ ] Confirm the learning is broadly applicable across consumers and scenarios.

## Notes

<!-- Anything reviewers should know: follow-ups, risks, manual steps. -->
