### PR TITLE
fix(scripts): make the hve-core cast guard fail closed

### DIFF
--- a/.changes/unreleased/20260812-cast-guard-fail-closed.md
+++ b/.changes/unreleased/20260812-cast-guard-fail-closed.md
@@ -1,0 +1,25 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **The upstream cast guard reported a clean verdict on a breaking change, and released it.**
+  `v0.12.9` moved the hve-core pin across a commit that removed seven agents the squad still binds —
+  `ADO Backlog Manager`, `AzDO PRD to WIT`, `GitHub Backlog Manager`, `Jira Backlog Manager`,
+  `Jira PRD to WIT`, `Agile Coach`, and `Product Manager Advisor`, the whole `product-owner` cast —
+  plus eighteen backlog prompts. The guard ran, listed every removal correctly, and still concluded
+  `non-breaking`. The cross-check that decides the verdict resolved `squad-src` as a **path relative
+  to the working directory** and enumerated it with `Get-ChildItem -Include`, which matched nothing
+  on the Linux runner while working locally on Windows; every other section of the same brief read
+  from an absolute path and was correct. `Get-SquadReferenceCount` now anchors the squad source on
+  the script's own location so the scan cannot depend on the caller's directory, and filters
+  extensions explicitly instead of relying on `-Include` against a directory
+  (`scripts/Get-HveCoreCastDelta.ps1`).
+- **Two independent fail-open paths let the silent zero reach a release tag.** The script returned
+  `Count = 0` when it could not read the squad source, making "cannot check" indistinguishable from
+  "nothing references it"; and every bump step in the sync workflow gated on
+  `is_breaking != 'true'`, which is equally satisfied by `false`, by an empty string, by an unset
+  output, and by a guard step that never ran. Either one alone would have stopped the release. The
+  script now **throws** when the squad source is missing or the scan enumerates no files, and the
+  workflow gates on `is_breaking == 'false'`, so only an explicit non-breaking verdict may release
+  (`scripts/Get-HveCoreCastDelta.ps1`, `.github/workflows/sync-hve-core.yml`).

--- a/.github/workflows/sync-hve-core.yml
+++ b/.github/workflows/sync-hve-core.yml
@@ -126,6 +126,12 @@ jobs:
       #    that happens the bump is refused and the run raises a labeled issue
       #    instead, which is what starts the squad through Watch Mode. Shipping the
       #    SHA anyway would release a squad whose roles resolve to nothing.
+      #
+      #    Every downstream bump step gates on `is_breaking == 'false'`, never on
+      #    `!= 'true'`. The negative form is also satisfied by an empty or unset
+      #    output, so a guard that crashed or never ran would read as a guard that
+      #    passed — which is exactly how 0.12.9 shipped a cast the squad no longer
+      #    resolves. Only an explicit `false` may release.
       - name: Guard against a breaking cast delta
         if: steps.check.outputs.skip != 'true'
         id: castguard
@@ -289,7 +295,7 @@ jobs:
       # ── Regenerate apm.yml at the new SHA ────────────────────────────────
       #    Script clones microsoft/hve-core at the SHA, rewrites all entries,
       - name: Regenerate apm.yml dependencies
-        if: steps.check.outputs.skip != 'true' && steps.castguard.outputs.is_breaking != 'true'
+        if: steps.check.outputs.skip != 'true' && steps.castguard.outputs.is_breaking == 'false'
         env:
           LATEST_SHA: ${{ steps.latest.outputs.sha }}
           DRY_RUN: ${{ inputs.dry_run }}
@@ -305,7 +311,7 @@ jobs:
       #    clears the fragments it consumed. -AllowEmpty lets a pure pin move
       #    still ship as a patch when no fragments are pending.
       - name: Assemble release
-        if: steps.check.outputs.skip != 'true' && steps.castguard.outputs.is_breaking != 'true' && inputs.dry_run != 'true'
+        if: steps.check.outputs.skip != 'true' && steps.castguard.outputs.is_breaking == 'false' && inputs.dry_run != 'true'
         id: bump
         shell: pwsh
         env:
@@ -317,7 +323,7 @@ jobs:
 
       # ── Commit and push ───────────────────────────────────────────────────
       - name: Commit and push
-        if: steps.check.outputs.skip != 'true' && steps.castguard.outputs.is_breaking != 'true' && inputs.dry_run != 'true'
+        if: steps.check.outputs.skip != 'true' && steps.castguard.outputs.is_breaking == 'false' && inputs.dry_run != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_DEPS_TOKEN }}
           NEW_VERSION: ${{ steps.bump.outputs.version }}
@@ -341,7 +347,7 @@ jobs:
       # dispatch release.yml explicitly. It will read the new version from
       # apm.yml and cut the tag + GitHub Release.
       - name: Trigger release
-        if: steps.check.outputs.skip != 'true' && steps.castguard.outputs.is_breaking != 'true' && inputs.dry_run != 'true'
+        if: steps.check.outputs.skip != 'true' && steps.castguard.outputs.is_breaking == 'false' && inputs.dry_run != 'true'
         env:
           GH_TOKEN: ${{ secrets.SYNC_DEPS_TOKEN }}
           RELEASE_VERSION: ${{ steps.bump.outputs.version }}

--- a/.gitignore
+++ b/.gitignore
@@ -52,3 +52,5 @@ apm_modules/
 !.copilot-tracking/squad/members/pr-*/**
 
 knowledge-docs/
+
+docs/planning/

--- a/scripts/Get-HveCoreCastDelta.ps1
+++ b/scripts/Get-HveCoreCastDelta.ps1
@@ -75,7 +75,7 @@ param(
 
     [Parameter(Mandatory = $false)]
     [ValidateNotNullOrEmpty()]
-    [string]$SquadSourceRoot = 'squad-src',
+    [string]$SquadSourceRoot = (Join-Path (Split-Path -Parent $PSScriptRoot) 'squad-src'),
 
     [Parameter(Mandatory = $false)]
     [string]$MarkdownPath,
@@ -241,7 +241,7 @@ function Get-SquadReferenceCount {
     )
 
     if (-not (Test-Path -LiteralPath $Root)) {
-        return [pscustomobject]@{ Count = 0; Files = @() }
+        throw "Squad source root '$Root' not found. The cross-check cannot run, and a guard that cannot read what it guards must not report a non-breaking verdict."
     }
 
     $escaped = [regex]::Escape($AgentName)
@@ -260,13 +260,21 @@ function Get-SquadReferenceCount {
         'prompt' { "$escaped\.prompt\.md|/$escaped(?![\w-])" }
     }
 
-    $hits = Get-ChildItem -LiteralPath $Root -Recurse -File -Include '*.md', '*.yml' -ErrorAction SilentlyContinue |
-        Select-String -Pattern $pattern -AllMatches -ErrorAction SilentlyContinue
+    # -Include against a directory path is inconsistent across platforms and silently
+    # matched nothing on the Linux runner, turning a breaking delta into a clean release.
+    $files = @(Get-ChildItem -LiteralPath $Root -Recurse -File |
+            Where-Object { $_.Extension -in '.md', '.yml' })
 
-    $files = @($hits | ForEach-Object { $_.Path } | Sort-Object -Unique)
+    if ($files.Count -eq 0) {
+        throw "Squad source root '$Root' contains no .md or .yml files. Refusing to report zero references from an empty scan."
+    }
+
+    $hits = $files | Select-String -Pattern $pattern -AllMatches
+
+    $matchedFiles = @($hits | ForEach-Object { $_.Path } | Sort-Object -Unique)
     return [pscustomobject]@{
         Count = @($hits).Count
-        Files = $files
+        Files = $matchedFiles
     }
 }
 


### PR DESCRIPTION
## Summary

`v0.12.9` bumped the hve-core pin across a commit that removed the entire `product-owner` cast, and the guard built to prevent exactly that reported `non-breaking` and released it. This makes the guard fail closed on both layers that let it through. `v0.12.9` has been reverted, its tag and release deleted, and `main` is back on `hve-core@db1be8f`.

## Type of change

- [ ] Feature / new content
- [x] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## What went wrong

The `Sync and Adapt` run for `db1be8f -> 3d681c9` listed every removal correctly — `ADO Backlog Manager`, `AzDO PRD to WIT`, `GitHub Backlog Manager`, `Jira Backlog Manager`, `Jira PRD to WIT`, `Agile Coach`, `Product Manager Advisor`, plus eighteen backlog prompts — and then concluded:

```text
- Verdict: non-breaking surface change
isBreaking : False
```

The same comparison run locally reports **BREAKING** with 7 referenced agents. Same script, same refs, same `squad-src`.

The split is precise. Everything read from the hve-core clone (an **absolute** temp path) was correct: added agents, skills, prompts. The only section that came back empty was the cross-check against `squad-src`, a **relative** path enumerated with `Get-ChildItem -LiteralPath ... -Include`. `squad-src` was demonstrably present in that job — the next step regenerated 46 squad entries out of it — so the tree was readable and the scan simply matched nothing on the Linux runner while working on Windows.

## Why a silent zero became a release

Two independent fail-open paths, either of which alone would have stopped it.

**The script treated "cannot check" as "nothing to worry about."** `Get-SquadReferenceCount` returned `Count = 0` when the root was missing, and suppressed scan errors with `-ErrorAction SilentlyContinue`. Zero references is the same value as "no references exist", and zero means safe.

**The workflow treated "no answer" as "passed."** Every bump step gated on `is_breaking != 'true'`, which is equally satisfied by `false`, by an empty string, by an unset output, and by a guard step that crashed or never ran.

## What changed

- `Get-SquadReferenceCount` anchors the squad source on `$PSScriptRoot/..`, so the scan cannot depend on the caller's working directory.
- Extensions are filtered explicitly via `Where-Object` instead of `-Include` against a directory path.
- The function **throws** when the root is missing or the scan enumerates zero files. A guard that cannot read what it guards must not return a verdict at all, let alone a clean one.
- Every bump step now gates on `is_breaking == 'false'`.

## Verification

- The real regression still reports `**BREAKING**` with the 7 referenced agents.
- Run from an unrelated working directory, it **still** reports `BREAKING` — this is the regression test for the root cause; before the fix that path returned zero references and a clean verdict.
- Pointed at a non-existent squad source, it throws rather than returning a verdict. Under GitHub's `pwsh` shell that fails the step, which fails the job, which releases nothing.

## Change fragment

- [x] Added a fragment under `.changes/unreleased/`
- [x] Its `bump` tracks ideas, not artifacts: `patch` — the guard already shipped, this corrects it
- [x] Its body reads as final release notes, not as a commit message
- [x] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

## After merge

The `db1be8f -> 3d681c9` move is still pending and still breaking. The next `Sync and Adapt` run should now **refuse** the bump and open a `squad/auto` adaptation issue instead. That issue is real work: hve-core replaced the removed agents with `Backlog Manager`, `Functional Planner`, and three `* Backlog Executor` subagents, so the `product-owner` roster row, both coordinator allowlists, and the routing rows need repointing.

## Notes

- `v0.12.9` was deleted rather than yanked, at the maintainer's decision, roughly six hours after publication.
- `main` was reverted with a revert commit pushed directly, not via a pull request: `pr-validation.yml` rejects any PR that moves the hve-core pin, and the revert necessarily moves it back to `db1be8f`.
