### PR TITLE
fix(scripts): scan squad-src with -Force so Linux does not hide .github

### DIFF
--- a/.changes/unreleased/20260812-cast-guard-hidden-dirs.md
+++ b/.changes/unreleased/20260812-cast-guard-hidden-dirs.md
@@ -1,0 +1,17 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **The cast guard could not see `squad-src/` on the runner, because Linux hides dot-directories.**
+  Every file in `squad-src/` lives under `.github/`, and a dot-prefixed entry is hidden on Linux, so
+  the `Get-ChildItem -Recurse` behind the reference cross-check never descended past `squad-src/`
+  and found zero references to anything. Windows has no dot-file convention, so the identical scan
+  matched all 53 files on a developer machine — which is why `v0.12.9` shipped a pin that removed
+  the entire `product-owner` cast while the guard reported `non-breaking`, and why nobody could
+  reproduce it locally. The scan now passes `-Force`
+  (`scripts/Get-HveCoreCastDelta.ps1`).
+- **The fail-closed guard did its job on first contact.** The preceding release turned the silent
+  zero into a hard stop, and the next manual run failed at the guard with `contains no .md or .yml
+  files` instead of quietly releasing. That failure is what identified the real cause; a guard that
+  refuses to answer when it cannot read its input is worth more than one that guesses.

--- a/scripts/Get-HveCoreCastDelta.ps1
+++ b/scripts/Get-HveCoreCastDelta.ps1
@@ -260,9 +260,10 @@ function Get-SquadReferenceCount {
         'prompt' { "$escaped\.prompt\.md|/$escaped(?![\w-])" }
     }
 
-    # -Include against a directory path is inconsistent across platforms and silently
-    # matched nothing on the Linux runner, turning a breaking delta into a clean release.
-    $files = @(Get-ChildItem -LiteralPath $Root -Recurse -File |
+    # -Force is load-bearing: every squad-src file lives under `.github/`, which Linux
+    # treats as hidden, and Get-ChildItem skips hidden entries without it. Windows has no
+    # such rule, so the scan matched everything locally and nothing on the runner.
+    $files = @(Get-ChildItem -LiteralPath $Root -Recurse -File -Force |
             Where-Object { $_.Extension -in '.md', '.yml' })
 
     if ($files.Count -eq 0) {


### PR DESCRIPTION
## Summary

The manual `Sync and Adapt` run failed at the cast guard with `contains no .md or .yml files`. That failure is the fail-closed guard from #60 working correctly — and it identified the real root cause, which is not the one #60 described.

## Type of change

- [ ] Feature / new content
- [x] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Root cause

Every file in `squad-src/` lives under `.github/`. `squad-src/` has exactly one child, and it is dot-prefixed:

```text
squad-src/
  .github/        <- the only entry
```

On Linux a dot-prefixed entry is **hidden**, and `Get-ChildItem -Recurse` skips hidden entries without `-Force`. So on the runner the scan never descended past `squad-src/` and returned zero files — which the cross-check read as "the squad references nothing that was removed", and the guard reported `non-breaking`.

Windows has no dot-file convention, so the identical scan sees everything:

```text
files seen WITHOUT -Force: 53
files seen WITH -Force:    53
```

Those two numbers being equal on Windows is the whole reason this survived review and could not be reproduced locally. On Linux the first is `0`.

This supersedes the cause given in #60. Anchoring the path on `$PSScriptRoot` and dropping `-Include` were both worth doing and are kept, but neither was the defect — `Test-Path` passed on the runner and the resolved path in the failure message was correct and absolute.

## What changed

One parameter, plus a comment recording why it is load-bearing:

```powershell
Get-ChildItem -LiteralPath $Root -Recurse -File -Force
```

## Why the previous PR still mattered

Before #60 this returned a silent zero and released a broken pin. After #60 it fails the step, fails the job, and releases nothing — and the error message named the exact condition, which is how the real cause surfaced within minutes. A guard that refuses to answer when it cannot read its input is worth more than one that guesses.

## Verification

- Windows counts with and without `-Force` are identical (53), confirming the platform asymmetry rather than a filter bug.
- `squad-src` contains zero tracked files outside `squad-src/.github/`, so the hidden directory is the entire tree.
- The real regression still reports `**BREAKING**` with the 7 referenced agents.

## Change fragment

- [x] Added a fragment under `.changes/unreleased/`
- [x] `patch` — corrects a guard that already shipped
- [x] Body reads as final release notes
- [x] Did not edit `CHANGELOG.md` or `apm.yml` `version:`

## After merge

Re-run `Sync and Adapt`. It should now refuse the `db1be8f -> 3d681c9` bump and open a `squad/auto` adaptation issue, which is the outcome the guard was built for.
