### PR TITLE
fix(workflows): make Watch Mode able to report its own failures

### DIFF
--- a/.changes/unreleased/20260812-watch-escalation-repo-flag.md
+++ b/.changes/unreleased/20260812-watch-escalation-repo-flag.md
@@ -1,0 +1,18 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **Watch Mode could not report its own failure.** Both `gh issue comment` calls ran in jobs that
+  never check out the repository — the escalation job has no checkout at all, and the no-changes
+  notice runs ahead of a checkout that is itself conditional on there being changes. With no git
+  remote to infer from, `gh` exited `not a git repository`, so the run that most needed to reach a
+  human was the one that could not. Both calls now pass `--repo` explicitly
+  (`.github/workflows/squad-watch.yml`).
+- **A missing `COPILOT_GITHUB_TOKEN` surfaced as a generic authentication error.** The Copilot CLI
+  reports `Authentication failed - your GitHub token may be invalid, expired, or lacking the
+  required permissions`, which reads like a problem with a token that exists and sends the reader to
+  inspect the PAT they already configured rather than the dedicated one they never created. The step
+  now checks the secret first and names it, along with the permission it needs and the fact that
+  `GH_TOKEN` and `SYNC_DEPS_TOKEN` cannot substitute for it
+  (`.github/workflows/squad-watch.yml`).

--- a/.github/workflows/squad-watch.yml
+++ b/.github/workflows/squad-watch.yml
@@ -404,6 +404,13 @@ jobs:
           MODEL_OVERRIDE: ${{ inputs.model }}
         run: |
           set -euo pipefail
+          # Fail on the missing secret rather than on the CLI's generic "Authentication
+          # failed", which reads like an expired token and sends you looking at the PAT
+          # you do have instead of the one you never created.
+          if [[ -z "${COPILOT_GITHUB_TOKEN}" ]]; then
+            echo "::error::Secret COPILOT_GITHUB_TOKEN is not set. Watch Mode needs a dedicated fine-grained PAT with the 'Copilot Requests' permission; see *Required configuration* at the top of this workflow. GH_TOKEN and SYNC_DEPS_TOKEN cannot substitute for it."
+            exit 1
+          fi
           RUN_MODEL="${MODEL_OVERRIDE:-$SQUAD_MODEL}"
           echo "::notice::Running the squad on model '${RUN_MODEL}'."
           copilot -p "$(cat "$SQUAD_PROMPT_FILE")" \
@@ -461,9 +468,12 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE: ${{ needs.interpret.outputs.target }}
+          REPO: ${{ github.repository }}
         run: |
           set -euo pipefail
-          gh issue comment "$ISSUE" --body "Watch Mode ran but produced no changes. Run log: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+          # --repo is required: this step runs before the conditional checkout, so gh has
+          # no git remote to infer from and would exit 'not a git repository'.
+          gh issue comment "$ISSUE" --repo "$REPO" --body "Watch Mode ran but produced no changes. Run log: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Checkout
         if: needs.interpret.outputs.hasChanges == 'true'
@@ -610,7 +620,11 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           ISSUE: ${{ needs.interpret.outputs.target }}
+          REPO: ${{ github.repository }}
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
         run: |
-          gh issue comment "$ISSUE" \
+          # --repo is required: this job never checks out, so gh has no git remote to infer
+          # from and would exit 'not a git repository' - silently losing the escalation on
+          # exactly the runs that most need to reach a human.
+          gh issue comment "$ISSUE" --repo "$REPO" \
             --body "Watch Mode run failed. This needs a human. Run log: ${RUN_URL}"


### PR DESCRIPTION
## Summary

The `Sync and Adapt` guard worked and opened issue #62, but the Watch Mode run that picked it up failed to authenticate, and then failed again trying to tell anyone. The authentication failure is a repository configuration gap, not a code defect; the silent escalation is a real defect and is what this PR fixes.

## Type of change

- [ ] Feature / new content
- [x] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## What failed

**Step 7, `Run the squad`:**

```text
COPILOT_GITHUB_TOKEN:
GH_TOKEN: ***
Error: Authentication failed
```

`COPILOT_GITHUB_TOKEN` prints empty while `GH_TOKEN` prints `***` — Actions masks non-empty secrets, so a blank value means the secret does not exist. `gh secret list` confirms only `SYNC_DEPS_TOKEN` is configured. That is a **configuration gap, fixed by adding the secret, not by this PR.**

**The escalation job, which should have reported that:**

```text
gh issue comment "$ISSUE" --body "Watch Mode run failed..."
failed to run git: fatal: not a git repository
```

That one **is** a defect.

## The defect

Both `gh issue comment` calls run in jobs that never check out the repository:

- The `escalate` job has no checkout step at all.
- The `No changes notice` step runs *before* the checkout in its job, and that checkout is conditional on `hasChanges == 'true'` while the notice fires on `hasChanges != 'true'` — so it never has one either.

Without a git remote, `gh` cannot infer the repository and exits. The result is the worst shape for an unattended pipeline: the run that most needed to reach a human was precisely the run that could not. Both calls now pass `--repo` explicitly.

## Also changed

The missing secret surfaced as the CLI's generic `Authentication failed - your GitHub token may be invalid, expired, or lacking the required permissions`. That wording points at a token that exists, so it sends the reader to inspect the PAT they already configured rather than the dedicated one they never created. The step now checks first and names the secret, the permission it needs, and the fact that `GH_TOKEN` and `SYNC_DEPS_TOKEN` cannot stand in for it.

## Required configuration (not fixed by this PR)

Watch Mode needs a repository secret `COPILOT_GITHUB_TOKEN`: a **dedicated fine-grained PAT whose only permission is `Copilot Requests`**. It is deliberately separate from `SYNC_DEPS_TOKEN` — the squad step runs with `--allow-all-tools`, so its credential is scoped to carry no repository write access. Reusing `SYNC_DEPS_TOKEN` would hand an all-tools agent a token that can push and comment.

## Change fragment

- [x] Added a fragment under `.changes/unreleased/`
- [x] `patch` — corrects workflows that already shipped
- [x] Body reads as final release notes
- [x] Did not edit `CHANGELOG.md` or `apm.yml` `version:`

## After merge

Add the secret, then re-run Watch Mode against issue #62 via `workflow_dispatch` with `issue_number: 62`. If it fails again, the escalation comment will now actually land on the issue.
