### PR TITLE
feat(workflows): release on demand with a rolling pre-release

### DIFF
--- a/.changes/README.md
+++ b/.changes/README.md
@@ -53,8 +53,18 @@ One fragment per idea. A pull request that does two unrelated things adds two fr
 
 ## What happens at release
 
-Merging a pull request that carries a fragment releases it. The fragment landing on `main` triggers the Release Prep workflow, which reads every pending fragment, resolves the new version from the highest `bump`, groups the bodies by `type`, prepends the assembled section to `CHANGELOG.md` with the standard consumer-install block and link reference, writes the new `version:` into `apm.yml`, deletes the fragments it consumed, and cuts the tag and GitHub Release.
+Merging a pull request that carries a fragment does not release it. The fragment lands in `.changes/unreleased/` and waits there with everything else merged that week.
 
-Because merging releases immediately, the pull request is where a wrong `bump` gets corrected. The PR check reports the version the merge would produce, and the maintainer can edit the `bump:` line directly in the pull request. `-Bump` and `-Version` overrides on `Invoke-ReleasePrep.ps1` remain for batches assembled by hand.
+Two workflows read that directory:
 
-`.changes/unreleased/` is empty between releases. That is the expected steady state.
+**Rolling Preview** runs on every merge to `main`. It renders the pending fragments into a single GitHub pre-release, named for the version they currently resolve to, and force-moves that pre-release's tag to the new head. Nothing is consumed and no file is written — the preview only reads. The result is one installable ref that always reflects what `main` currently adds up to:
+
+```powershell
+apm install "Peter-N91/hve-squad#v0.14.0-pre"
+```
+
+**Release Prep** runs only when a maintainer dispatches it. It reads every pending fragment, resolves the new version from the highest `bump`, groups the bodies by `type`, prepends the assembled section to `CHANGELOG.md` with the standard consumer-install block and link reference, writes the new `version:` into `apm.yml`, deletes the fragments it consumed, cuts the tag and GitHub Release, and retires the pre-release. Nothing releases on a timer.
+
+Releasing is therefore a decision about readiness, not a date. A quick fix can ship as soon as it is verified in the preview; a larger change can sit in preview for as long as it needs. Whatever is pending when the workflow is dispatched goes out together, as one version, at the highest `bump` any pending fragment asked for. The pull request is still where a wrong `bump` gets corrected — the PR check reports the version the batch currently resolves to, and the maintainer can edit the `bump:` line directly in the pull request. `-Bump` and `-Version` overrides on `Invoke-ReleasePrep.ps1` remain for batches assembled by hand.
+
+`.changes/unreleased/` is empty from a release until the next merge. That is the expected steady state.

--- a/.changes/unreleased/20260814-release-on-demand-with-a-rolling-pre-release.md
+++ b/.changes/unreleased/20260814-release-on-demand-with-a-rolling-pre-release.md
@@ -1,0 +1,10 @@
+---
+bump: minor
+type: Changed
+---
+
+- **Every merge cut a release.** A fragment landing on `main` assembled the CHANGELOG, bumped `apm.yml`, and tagged immediately, and the daily hve-core sync cut a release of its own on top, so a quiet week still produced several versions and nothing was ever installed before it shipped. Releasing is now a deliberate act: `.github/workflows/release-prep.yml` runs on manual dispatch only, ships everything pending as one version at the highest `bump` any fragment asked for, and nothing goes out on a timer.
+- **Merged work is now installable before it ships.** `.github/workflows/preview.yml` keeps a single GitHub pre-release in sync with `main`, tagged with the version the pending fragments resolve to (`v0.15.0-pre`) and force-moved on every merge, so a change can be installed and tested the moment it lands. It only reads: no fragment is consumed, no version is bumped, and `CHANGELOG.md` is untouched. A quick fix can ship as soon as it is verified there, while a larger change sits in preview until it is ready.
+- **The hve-core sync queues instead of releasing.** `.github/workflows/sync-hve-core.yml` now records a pin move as a change fragment and pushes it, leaving the release to a maintainer. The cast-delta guard and the Watch Mode handoff are unchanged.
+- **A fix can ship without shipping what is not ready.** A release carries a commit, so a tag cut from the default branch contains everything merged into it. `release-prep.yml` and `release.yml` accept a `ref` input, which lets a hotfix be cut off the last release tag and released on its own, leaving the pending batch and its preview untouched. `release.yml` also declines the Latest badge when the version it is cutting is lower than the current latest, and `pr-validation.yml` accepts a `release-merge-back` label so the hotfix can be merged back with the release state Release Prep already wrote.
+- **`Invoke-ReleasePrep.ps1` gained `-SectionOutFile` and `-InstallRef`** so the preview can render the pending release notes and point the install snippet at the preview tag without consuming anything.

--- a/.github/workflows/pr-validation.yml
+++ b/.github/workflows/pr-validation.yml
@@ -55,7 +55,11 @@ jobs:
           echo "Changed files:"
           cat /tmp/changed.txt
 
+      # Exempt only the hotfix merge-back, which carries a release that already
+      # happened on another branch: its CHANGELOG section and version bump were
+      # written by Release Prep, not by hand, and main needs both.
       - name: Reject edits to release state
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'release-merge-back') }}
         env:
           BASE_SHA: ${{ steps.diff.outputs.base_sha }}
         run: |
@@ -88,7 +92,7 @@ jobs:
           fi
 
       - name: Require a change fragment
-        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') }}
+        if: ${{ !contains(github.event.pull_request.labels.*.name, 'skip-changelog') && !contains(github.event.pull_request.labels.*.name, 'release-merge-back') }}
         env:
           BASE_SHA: ${{ steps.diff.outputs.base_sha }}
         run: |
@@ -112,6 +116,7 @@ jobs:
             $verdict.Trim()
             '```'
             ''
-            'Merging to `main` releases this immediately. Wrong level? Edit the `bump:` line'
-            'in the fragment from the Files changed tab before merging.'
+            'Merging does not release. It publishes to the rolling pre-release, and this'
+            'version ships when a maintainer dispatches Release Prep. Wrong level? Edit the'
+            '`bump:` line in the fragment from the Files changed tab before merging.'
           ) | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,155 @@
+name: Rolling Preview
+
+# Every merge to main refreshes a single pre-release instead of cutting a new one.
+#
+# The release that main is currently accumulating exists continuously as one
+# GitHub pre-release, named for the version the pending fragments resolve to
+# (v0.14.0-pre). Every merge re-renders its notes from .changes/unreleased/ and
+# force-moves its tag to the new head, so testers always have one installable ref:
+#
+#   apm install "Peter-N91/hve-squad#v0.14.0-pre"
+#
+# Nothing here consumes a fragment, edits CHANGELOG.md, or bumps apm.yml. Those
+# stay release outputs, written only when release-prep.yml is dispatched by hand.
+# This workflow only ever reads, which is why it can run on every single merge.
+#
+# The tag name tracks the resolved version, so a minor fragment landing midweek
+# renames the pre-release from v0.13.4-pre to v0.14.0-pre. The stale one is
+# deleted so exactly one pre-release is open at any time.
+#
+# GITHUB_TOKEN is enough here: unlike release-prep.yml and sync-hve-core.yml,
+# nothing downstream needs to be triggered by what this workflow pushes.
+
+on:
+  push:
+    branches:
+      - main
+
+# Only the newest head matters — an in-flight preview for a commit that is
+# already superseded is wasted work, so this cancels rather than queues.
+concurrency:
+  group: preview-main
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  preview:
+    name: Refresh rolling pre-release
+    runs-on: ubuntu-latest
+    # The release commit consumes the fragments this preview renders, and the
+    # pre-release is deleted by that same run. Reacting to it would rebuild a
+    # preview for a release that just shipped.
+    if: ${{ !startsWith(github.event.head_commit.message, 'chore(release):') }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      # ── Resolve what main currently adds up to ────────────────────────────
+      #    -DryRun writes nothing and consumes nothing. It only reports the
+      #    version the pending fragments resolve to.
+      - name: Resolve pending release
+        id: pending
+        shell: pwsh
+        run: ./scripts/Invoke-ReleasePrep.ps1 -DryRun -GitHubOutput
+
+      - name: Compute preview tag
+        id: tag
+        env:
+          VERSION: ${{ steps.pending.outputs.version }}
+        run: echo "tag=v${VERSION}-pre" >> "$GITHUB_OUTPUT"
+
+      # ── Retire pre-releases that no longer match ──────────────────────────
+      #    Covers the rename case (a minor fragment landed midweek) and the case
+      #    where a release consumed the fragments, leaving nothing pending. With
+      #    nothing pending there is no resolved version, so the tag to keep is a
+      #    name no release can have and every pre-release is retired — the
+      #    preview closes itself rather than advertising a shipped release.
+      - name: Remove superseded pre-releases
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          KEEP: ${{ steps.tag.outputs.tag }}
+        run: |
+          mapfile -t found < <(
+            gh release list --limit 100 --json tagName,isPrerelease \
+              --jq '.[] | select(.isPrerelease) | .tagName' \
+              | grep -E -- '-pre$' || true
+          )
+          for stale in "${found[@]}"; do
+            if [[ -n "$stale" && "$stale" != "$KEEP" ]]; then
+              echo "::notice::Removing superseded pre-release $stale"
+              gh release delete "$stale" --yes --cleanup-tag
+            fi
+          done
+
+      - name: Report nothing pending
+        if: steps.pending.outputs.has_changes != 'true'
+        run: |
+          echo "::notice::No fragments pending in .changes/unreleased — nothing to preview."
+          echo "No pending fragments. The latest release is still the newest installable ref." \
+            >> "$GITHUB_STEP_SUMMARY"
+
+      # ── Render the pre-release body ───────────────────────────────────────
+      #    Second pass now that the tag is known, so the install snippet inside
+      #    the notes points at the preview tag rather than the unreleased version.
+      - name: Render notes
+        if: steps.pending.outputs.has_changes == 'true'
+        shell: pwsh
+        env:
+          TAG: ${{ steps.tag.outputs.tag }}
+          VERSION: ${{ steps.pending.outputs.version }}
+        run: |
+          ./scripts/Invoke-ReleasePrep.ps1 -DryRun -SectionOutFile 'preview-notes.md' -InstallRef $env:TAG
+
+          $banner = @(
+            '> **Rolling preview — not a release.**'
+            "> Rebuilt on every merge to ``main``. Ships as ``v$env:VERSION`` when a maintainer cuts the release."
+            '> The tag moves, so re-run the install command to pick up the newest build.'
+            ''
+          )
+          $body = ($banner -join "`n") + (Get-Content -LiteralPath 'preview-notes.md' -Raw)
+          Set-Content -LiteralPath 'preview-body.md' -Value $body -Encoding utf8NoBOM
+          Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY -Value $body
+
+      # ── Move the tag, then publish or refresh the pre-release ─────────────
+      - name: Move preview tag
+        if: steps.pending.outputs.has_changes == 'true'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          SHA: ${{ github.sha }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git tag -f "$TAG" "$SHA"
+          git push --force origin "refs/tags/$TAG"
+
+      - name: Publish or refresh pre-release
+        if: steps.pending.outputs.has_changes == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.tag.outputs.tag }}
+          SHA: ${{ github.sha }}
+        run: |
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            gh release edit "$TAG" \
+              --title "$TAG (rolling preview)" \
+              --notes-file preview-body.md \
+              --prerelease
+            echo "::notice::Refreshed pre-release $TAG"
+          else
+            gh release create "$TAG" \
+              --title "$TAG (rolling preview)" \
+              --notes-file preview-body.md \
+              --prerelease \
+              --target "$SHA"
+            echo "::notice::Opened pre-release $TAG"
+          fi

--- a/.github/workflows/release-prep.yml
+++ b/.github/workflows/release-prep.yml
@@ -10,14 +10,23 @@ name: Release Prep
 #      the section this run just wrote.
 #
 # Triggers:
-#   push to main touching .changes/unreleased/**
-#     A merged pull request that carries a fragment releases immediately. This
-#     is the normal path; nobody has to remember to cut a release. A pull
-#     request with no fragment (the `skip-changelog` label) touches nothing here
-#     and releases nothing.
-#   workflow_dispatch
-#     Manual, and the only way to overrule the level the fragments resolved to
-#     or to pin an exact version.
+#   workflow_dispatch (only)
+#     Releasing is a decision, not a timer. Fragments accumulate on main and stay
+#     installable through the rolling pre-release for as long as they need to,
+#     so a quick fix can ship the moment it is verified and a larger change can
+#     sit in preview until it is ready. Nothing releases until someone runs this.
+#
+# Merging does not release. A merged fragment lands in .changes/unreleased/ and
+# is picked up by preview.yml, which keeps one rolling pre-release in sync with
+# main so the pending batch can be installed and tested before this workflow
+# ships it. Whatever is pending on the released ref is what goes out, as one
+# version, at the highest `bump` any pending fragment asked for.
+#
+# The `ref` input exists because a release ships a *commit*, not a selection of
+# fragments: a tag cut from main contains everything merged into main, whatever
+# the CHANGELOG says. So when main holds work that must not ship yet, a fix is
+# released from a hotfix branch cut off the last release tag instead. See the
+# hotfix section in CONTRIBUTING.md.
 #
 # Step 3 is explicit because pushes authored by GITHUB_TOKEN do not trigger
 # other workflows — the same reason sync-hve-core.yml dispatches rather than
@@ -25,11 +34,6 @@ name: Release Prep
 # Contents: read and write and Actions: read and write.
 
 on:
-  push:
-    branches:
-      - main
-    paths:
-      - '.changes/unreleased/**'
   workflow_dispatch:
     # checkov:skip=CKV_GHA_7:Manual dispatch (write access required); inputs are passed through env and never interpolated into the pwsh script body.
     inputs:
@@ -52,6 +56,11 @@ on:
         required: false
         default: false
         type: boolean
+      ref:
+        description: 'Branch to release from. Leave as main unless cutting a hotfix off a release tag.'
+        required: false
+        default: main
+        type: string
 
 # Shared with sync-hve-core.yml: both push a release commit to main, and two of
 # them racing means one loses to a non-fast-forward.
@@ -66,12 +75,6 @@ jobs:
   prepare:
     name: Assemble changelog and bump version
     runs-on: ubuntu-latest
-    # The release commit itself deletes the fragments it consumed, which matches
-    # the path filter above. Without this guard that deletion re-triggers the run.
-    if: >
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'push' &&
-       !startsWith(github.event.head_commit.message, 'chore(release):'))
     permissions:
       contents: write
       actions: write
@@ -80,7 +83,7 @@ jobs:
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           persist-credentials: false
-          ref: main
+          ref: ${{ inputs.ref }}
 
       - name: Assemble release
         id: prep
@@ -105,6 +108,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_DEPS_TOKEN }}
           NEW_VERSION: ${{ steps.prep.outputs.version }}
+          REF: ${{ inputs.ref }}
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
@@ -116,14 +120,42 @@ jobs:
             exit 0
           fi
           git commit -m "chore(release): $NEW_VERSION"
-          git push origin main
-          echo "::notice::Pushed release commit for v$NEW_VERSION"
+          git push origin "HEAD:${REF}"
+          echo "::notice::Pushed release commit for v$NEW_VERSION to ${REF}"
 
+      # Dispatched from main so the workflow definition is always the current one,
+      # with the ref to tag passed as an input. A hotfix branch cut off an old
+      # release tag carries that tag's copy of release.yml, which may predate the
+      # ref input entirely.
       - name: Trigger release
         if: steps.prep.outputs.has_changes == 'true' && inputs.dry_run != true
         env:
           GH_TOKEN: ${{ secrets.SYNC_DEPS_TOKEN }}
           NEW_VERSION: ${{ steps.prep.outputs.version }}
+          REF: ${{ inputs.ref }}
         run: |
-          gh workflow run release.yml --ref main
-          echo "::notice::Triggered release.yml for v${NEW_VERSION}"
+          gh workflow run release.yml --ref main -f ref="$REF"
+          echo "::notice::Triggered release.yml for v${NEW_VERSION} on ${REF}"
+
+      # The fragments this run consumed are what the pre-release was rendering,
+      # so it now describes a release that has shipped. preview.yml skips the
+      # release commit, so nobody else will clear it.
+      #
+      # A hotfix released off another branch consumed only that branch's
+      # fragments; main's batch is still pending, so its preview must survive.
+      - name: Retire the rolling pre-release
+        if: steps.prep.outputs.has_changes == 'true' && inputs.dry_run != true && inputs.ref == 'main'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mapfile -t found < <(
+            gh release list --limit 100 --json tagName,isPrerelease \
+              --jq '.[] | select(.isPrerelease) | .tagName' \
+              | grep -E -- '-pre$' || true
+          )
+          for stale in "${found[@]}"; do
+            if [[ -n "$stale" ]]; then
+              echo "::notice::Retiring pre-release $stale"
+              gh release delete "$stale" --yes --cleanup-tag
+            fi
+          done

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,11 @@ on:
         required: false
         default: false
         type: boolean
+      ref:
+        description: 'Branch to cut the tag from. Leave as main unless releasing a hotfix branch.'
+        required: false
+        default: main
+        type: string
   push:
     branches:
       - main
@@ -51,6 +56,7 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
+          ref: ${{ inputs.ref || 'main' }}
 
       # ── Manual dispatch only: bump apm.yml version if requested ─────────
       - name: Bump apm.yml version (manual override)
@@ -58,6 +64,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           INPUT_VERSION: ${{ inputs.version }}
+          REF: ${{ inputs.ref || 'main' }}
         run: |
           NEW_VER="$INPUT_VERSION"
           # Reject anything that isn't a plain semver, so it can't break out of the sed below.
@@ -76,7 +83,7 @@ jobs:
               "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
             git add apm.yml
             git commit -m "chore(release): bump to $NEW_VER"
-            git push origin main
+            git push origin "HEAD:${REF}"
           fi
 
       # ── Resolve version ──────────────────────────────────────────────────
@@ -124,12 +131,27 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAG: ${{ steps.version.outputs.tag }}
+          VERSION: ${{ steps.version.outputs.version }}
           DRAFT: ${{ inputs.draft }}
         run: |
           ARGS=(
             "$TAG"
             --title "$TAG"
             --notes-file /tmp/release_notes.md
+            --target "$GITHUB_SHA"
           )
           [[ "$DRAFT" == "true" ]] && ARGS+=(--draft)
+
+          # A hotfix cut off an older line is newer by date but lower by version,
+          # and GitHub would otherwise hand it the Latest badge over the release
+          # that supersedes it.
+          CURRENT_LATEST=$(gh release view --json tagName --jq '.tagName' 2>/dev/null || true)
+          if [[ -n "$CURRENT_LATEST" ]]; then
+            HIGHEST=$(printf '%s\n%s\n' "${CURRENT_LATEST#v}" "$VERSION" | sort -V | tail -1)
+            if [[ "$HIGHEST" != "$VERSION" ]]; then
+              ARGS+=(--latest=false)
+              echo "::notice::$TAG is lower than the current latest ($CURRENT_LATEST) — not marking it latest."
+            fi
+          fi
+
           gh release create "${ARGS[@]}"

--- a/.github/workflows/sync-hve-core.yml
+++ b/.github/workflows/sync-hve-core.yml
@@ -23,13 +23,13 @@ name: Sync and Adapt
 #        - clones microsoft/hve-core at that exact SHA
 #        - rewrites all microsoft/hve-core entries with the new SHA
 #        - leaves squad entries pointing at the default upstream slug
-#   6. Runs Invoke-ReleasePrep.ps1, which resolves the new version from any
-#      change fragments contributors merged since the last release, adds this
-#      SHA move as one more Changed entry, prepends the CHANGELOG section, and
-#      writes the version into apm.yml.
-#   7. Commits apm.yml, CHANGELOG.md, and the consumed fragments, then pushes to main.
-#   8. Dispatches release.yml to cut the tag and GitHub Release
-#      (required because GITHUB_TOKEN-authored pushes do not trigger workflows).
+#   6. Records the pin move as a change fragment under .changes/unreleased/,
+#      exactly as a contributor would.
+#   7. Commits apm.yml and the fragment, then pushes to main.
+#
+# It no longer cuts a release. The fragment reaches testers within minutes as
+# part of the rolling pre-release (preview.yml) and reaches consumers when a
+# maintainer dispatches release-prep.yml.
 #
 # No local hve-core mirror involved — all content is referenced directly
 # from microsoft/hve-core at a pinned commit SHA.
@@ -266,8 +266,9 @@ jobs:
               '## After merge',
               '',
               'Nothing further is required. The fragment this pull request adds lands in',
-              '`.changes/unreleased/` on `main`, which triggers **Release Prep**: it assembles the',
-              'CHANGELOG section, bumps `apm.yml` to the minor, and cuts the tag and GitHub Release.',
+              '`.changes/unreleased/` on `main`, where **Rolling Preview** publishes it as an',
+              'installable pre-release within minutes. It ships to consumers when a maintainer',
+              'dispatches **Release Prep**.',
               '',
               '## Cast delta',
               '',
@@ -304,54 +305,45 @@ jobs:
           [[ "$DRY_RUN" == "true" ]] && ARGS+=(-DryRun)
           pwsh scripts/Update-ApmDependencies.ps1 "${ARGS[@]}"
 
-      # ── Assemble the release from pending change fragments ────────────────
-      #    Invoke-ReleasePrep.ps1 owns the version and the CHANGELOG. It resolves
-      #    the bump from whatever fragments contributors have merged since the
-      #    last release, appends this SHA move as one more Changed entry, and
-      #    clears the fragments it consumed. -AllowEmpty lets a pure pin move
-      #    still ship as a patch when no fragments are pending.
-      - name: Assemble release
+      # ── Record the pin move as a change fragment ─────────────────────────
+      #    A pin move is a change like any other, so it queues the same way a
+      #    contributor's does: as a fragment. It becomes installable within
+      #    minutes through the rolling pre-release and ships to consumers with
+      #    the next dispatched release. This step used to assemble and ship a
+      #    release of its own, which is why a week with no contributions could
+      #    still cut a release every morning.
+      - name: Record the pin move
         if: steps.check.outputs.skip != 'true' && steps.castguard.outputs.is_breaking == 'false' && inputs.dry_run != 'true'
-        id: bump
         shell: pwsh
         env:
           HVE_CORE_SHORT_SHA: ${{ steps.latest.outputs.short_sha }}
           HVE_CORE_SHA: ${{ steps.latest.outputs.sha }}
         run: |
-          $entry = "- Updated hve-core dependency pin to ``$env:HVE_CORE_SHORT_SHA`` ($env:HVE_CORE_SHA)."
-          ./scripts/Invoke-ReleasePrep.ps1 -AllowEmpty -GitHubOutput -ExtraEntry $entry
+          $body = "- Updated hve-core dependency pin to ``$env:HVE_CORE_SHORT_SHA`` ($env:HVE_CORE_SHA)."
+          ./scripts/New-ChangeFragment.ps1 -Type Changed -Bump patch -Force `
+            -Title "sync hve-core $env:HVE_CORE_SHORT_SHA" `
+            -Body $body
 
       # ── Commit and push ───────────────────────────────────────────────────
       - name: Commit and push
         if: steps.check.outputs.skip != 'true' && steps.castguard.outputs.is_breaking == 'false' && inputs.dry_run != 'true'
         env:
           GITHUB_TOKEN: ${{ secrets.SYNC_DEPS_TOKEN }}
-          NEW_VERSION: ${{ steps.bump.outputs.version }}
           LATEST_SHORT: ${{ steps.latest.outputs.short_sha }}
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin \
             "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
-          git add apm.yml CHANGELOG.md .changes/unreleased
+          git add apm.yml .changes/unreleased
           if ! git diff --cached --quiet; then
-            git commit -m "chore(release): bump to ${NEW_VERSION} with hve-core@${LATEST_SHORT}"
+            # Deliberately not a `chore(release):` message: that prefix is how
+            # preview.yml recognises the release commit and skips it, and this
+            # commit must reach the preview so the pin move becomes installable.
+            git commit -m "chore(deps): sync hve-core to ${LATEST_SHORT}"
             git push origin main
-            echo "::notice::Pushed release bump to v${NEW_VERSION} (hve-core@${LATEST_SHORT})"
+            echo "::notice::Queued hve-core@${LATEST_SHORT} for the next release."
           else
             echo "::notice::No changes after regeneration — nothing to commit."
           fi
-
-      # ── Dispatch release workflow ───────────────────────────────────────────
-      # GITHUB_TOKEN-authored pushes do not trigger other workflows, so we
-      # dispatch release.yml explicitly. It will read the new version from
-      # apm.yml and cut the tag + GitHub Release.
-      - name: Trigger release
-        if: steps.check.outputs.skip != 'true' && steps.castguard.outputs.is_breaking == 'false' && inputs.dry_run != 'true'
-        env:
-          GH_TOKEN: ${{ secrets.SYNC_DEPS_TOKEN }}
-          RELEASE_VERSION: ${{ steps.bump.outputs.version }}
-        run: |
-          gh workflow run release.yml --ref main
-          echo "::notice::Triggered release.yml for v${RELEASE_VERSION}"
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,7 +13,7 @@ hve-squad gets better when a durable fix found in one environment reaches every 
 4. Open a pull request against the default branch.
 5. A maintainer reviews, requests changes when needed, and merges.
 
-Consumers receive the merged change the next time they run `apm run sync-deps`.
+Merging publishes the change to the rolling pre-release within minutes, so it can be installed and tested straight away (see [Testing before a release](#testing-before-a-release)). It reaches consumers pinned to a released version when a maintainer cuts the next release, which happens when the pending work is judged ready rather than on a schedule.
 
 ## Recording your change
 
@@ -44,7 +44,7 @@ The script asks four things and writes the file for you:
 
 Adding an agent is not a minor. Adding the *concept* the agent belongs to is. Ten agents that all serve one idea that already ships are ten patches, not ten minors. When in doubt choose `patch` — the maintainer sees the resolved level on the pull request check and corrects the line before merging, and raising is cheap while an accidental minor is permanent.
 
-Merging your pull request releases it: the fragment landing on the default branch is what assembles the CHANGELOG section, bumps the version, and cuts the tag.
+Merging your pull request does not release it. The fragment waits in `.changes/unreleased/` with everything else already merged, and a maintainer cuts a release when that batch is ready — which may be the same hour for a quick fix, or later for something that needs time in testing. In the meantime your change is installable from the rolling pre-release, which is rebuilt on every merge — see [Testing before a release](#testing-before-a-release).
 
 If you prefer to skip the prompts, pass the values directly:
 
@@ -69,6 +69,49 @@ Write the entry as markdown bullets starting with `- `, because the release step
 
 A pull request that changes nothing a consumer would notice can carry the `skip-changelog` label instead, which a maintainer applies. That skips the version bump too: the version is resolved from fragments at release time, so a pull request that contributes no fragment contributes no bump.
 
+The full format reference lives in [.changes/README.md](.changes/README.md).
+
+## Testing before a release
+
+Releases are cut by hand when the pending work is judged ready, so merging is no longer the moment a change reaches consumers. What merging does reach is the **rolling pre-release**: one GitHub pre-release, rebuilt on every merge to the default branch, tagged with the version the pending fragments currently resolve to.
+
+Install it into a scratch project to try the merged batch before it ships:
+
+```powershell
+apm install "Peter-N91/hve-squad#v0.14.0-pre" --target copilot
+```
+
+The exact tag is on the [Releases page](https://github.com/Peter-N91/hve-squad/releases), marked as a pre-release. Two things follow from how it is built:
+
+* **The tag moves.** Re-run the install to pick up the newest build. It is a channel, not a fixed point, so it is for testing rather than for anything you depend on.
+* **The name can change.** The tag tracks the resolved version, so a `minor` fragment landing midweek renames the pre-release from `v0.13.4-pre` to `v0.14.0-pre` and the old one is deleted.
+
+Nothing about the preview consumes a fragment or writes to `CHANGELOG.md`. The release is assembled from the same fragments the preview rendered, so what you tested is what ships.
+
+## Shipping a fix without shipping everything else
+
+A release ships a **commit**, not a selection of fragments. The tag is cut from the branch head, so a release from the default branch contains everything merged into it, whatever the CHANGELOG happens to list. Choosing which fragments to consume changes the release notes, not the code.
+
+That leaves two cases, and only the second one needs anything unusual.
+
+**The default branch is shippable.** Dispatch Release Prep. Your fix goes out along with everything else pending, as one version. If a pending fragment asked for `minor`, that version is a minor — and it still contains your patch, so consumers get the fix. This is almost always the right answer, and the version number is not worth optimising.
+
+**The default branch holds something that must not ship yet.** Then a release from it would carry that work out with your fix, so the fix has to come from somewhere that does not contain it: a hotfix branch cut off the last release tag.
+
+```powershell
+git switch --detach v0.14.0
+git switch -c hotfix/v0.14.1
+# apply the fix, then record it
+apm run change            # Type: Fixed, Bump: patch
+git push -u origin hotfix/v0.14.1
+```
+
+Dispatch **Release Prep** with `ref` set to `hotfix/v0.14.1`. It assembles the CHANGELOG from that branch's fragments only, bumps `apm.yml` to `0.14.1`, and cuts the tag from that branch. The rolling pre-release on the default branch is left alone, because the batch it describes is still pending.
+
+Then merge the hotfix branch back so the fix is not lost on the next release, and label that pull request `release-merge-back`. The label is what allows it to carry the `CHANGELOG.md` section and the version bump that Release Prep already wrote, both of which a normal pull request is rejected for touching.
+
+A hotfix released after a higher version does not steal the **Latest** badge: the release workflow compares versions and declines it when the tag is lower than the current latest.
+
 ## Adding an agent, skill, prompt, or instruction
 
 New squad content lives under `squad-src/.github/{agents,skills,prompts,instructions}/`, and `apm.yml` carries a generated list of every file the package ships. After adding your files, regenerate that list:
@@ -78,8 +121,6 @@ apm run sync-deps
 ```
 
 That rewrites `dependencies:` in `apm.yml` to include your new files, and commits are expected to contain it. It deliberately does **not** move the `microsoft/hve-core` pin: with no `-Ref`, the script stays on whatever SHA `apm.yml` already names. Moving that pin re-points the entire package at a different upstream revision, which is a separate reviewed operation owned by the scheduled sync workflow, and CI rejects a pull request that does it.
-
-The full format reference lives in [.changes/README.md](.changes/README.md).
 
 ## Proposing a shared learning
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ See [Getting Started](https://peter-n91.github.io/hve-squad/getting-started.html
 - See [CHANGELOG.md](CHANGELOG.md) for what is included in each version.
 - Consumers can pin to a tagged version, for example `apm install "Peter-N91/hve-squad#vX.Y.z"`.
 
+Releases are cut by hand, when the pending work is judged ready rather than on a schedule.
+Between releases, everything already merged is installable from a rolling pre-release tagged
+with the version it is going to become:
+
+```powershell
+apm install "Peter-N91/hve-squad#vX.Y.z-pre" --target copilot
+```
+
+That tag moves on every merge, so re-run the command to pick up the newest build. Use it
+to try a fix before it ships; pin a released version for anything you depend on.
+
 ## License
 
 This project is licensed under the MIT License. See [LICENSE](LICENSE) for details.

--- a/docs/contributing.html
+++ b/docs/contributing.html
@@ -123,10 +123,19 @@ type: Fixed
         per idea &mdash; a pull request doing two unrelated things adds two fragments.
       </p>
       <p>
-        Merging your pull request <strong>releases it</strong>: the fragment landing on the default
-        branch is what assembles the CHANGELOG section, resolves the new version from the highest
-        <code>bump</code> among all pending fragments, writes it into <code>apm.yml</code>, and cuts the
-        tag. The full format reference lives in
+        Merging your pull request <strong>does not release it</strong>. The fragment waits in
+        <code>.changes/unreleased/</code> with everything else already merged, and a maintainer cuts a
+        release when that batch is ready &mdash; the same hour for a quick fix, or later for something
+        that needs time in testing. In the meantime the merge is published to the
+        <strong>rolling pre-release</strong>, so your change is installable and testable within minutes:
+      </p>
+      <pre><code>apm install "Peter-N91/hve-squad#v0.15.0-pre" --target copilot</code></pre>
+      <p>
+        The exact tag is on the
+        <a href="https://github.com/Peter-N91/hve-squad/releases">Releases page</a>, marked as a
+        pre-release. It is a channel rather than a fixed point: the tag moves on every merge, and it is
+        renamed when a <code>minor</code> fragment lands midweek. Pin a released version for anything
+        you depend on. The full format reference lives in
         <a href="https://github.com/Peter-N91/hve-squad/blob/main/.changes/README.md">.changes/README.md</a>.
       </p>
 

--- a/docs/maintaining.html
+++ b/docs/maintaining.html
@@ -151,13 +151,13 @@ flowchart TD
 
       <h3>Path 1 &mdash; mechanical (no cast change)</h3>
       <p>
-        <code>sync-hve-core.yml</code> moves the pinned SHA, then hands the version and the CHANGELOG
-        to <code>Invoke-ReleasePrep.ps1</code> &mdash; so the nightly sync also flushes whatever change
-        fragments contributors merged during the day, and the pin move is recorded as one more
-        <em>Changed</em> entry alongside them. It pushes and dispatches the release. One addition to the
-        older behavior: it runs the cast-delta script as a <strong>guard</strong> first. A SHA move
-        cannot repoint a roster row, and shipping it anyway releases a squad whose roles resolve to
-        nothing &mdash; which is exactly what happened in <code>0.10.11</code>.
+        <code>sync-hve-core.yml</code> moves the pinned SHA and records the move as a change fragment,
+        exactly as a contributor would &mdash; so the pin move queues alongside whatever contributors
+        merged that day and ships with the next release someone cuts, instead of cutting a release of
+        its own every morning. It pushes and stops there. One addition to the older behavior: it runs
+        the cast-delta script as a <strong>guard</strong> first. A SHA move cannot repoint a roster row,
+        and shipping it anyway releases a squad whose roles resolve to nothing &mdash; which is exactly
+        what happened in <code>0.10.11</code>.
       </p>
 
       <h3>Path 2 &mdash; adaptive (the cast changed)</h3>
@@ -185,9 +185,10 @@ flowchart TD
       </p>
       <div class="callout">
         <p>
-          Merging the adaptation pull request <strong>cuts the minor release by itself</strong>. The
-          fragment lands in <code>.changes/unreleased/</code> on <code>main</code>, which is the
-          trigger for <strong>Release Prep</strong>. Nothing else is required of you.
+          Merging the adaptation pull request <strong>queues the minor release by itself</strong>. The
+          fragment lands in <code>.changes/unreleased/</code> on <code>main</code>, where
+          <strong>Rolling Preview</strong> publishes it as an installable pre-release within minutes.
+          It ships to consumers with the next release you cut.
         </p>
       </div>
 
@@ -444,19 +445,33 @@ pwsh -File scripts/Invoke-ReleasePrep.ps1 -Version 1.0.0        # exact number, 
         pending fragments selects it.
       </p>
       <p>
-        <strong>The normal path needs nothing from you.</strong> Merging a pull request that carries a
-        fragment pushes it to <code>.changes/unreleased/</code> on <code>main</code>, which triggers
-        <strong>Release Prep</strong>. That run resolves the version, prepends the CHANGELOG section
-        with the consumer-install block and the link reference, writes <code>version:</code> into
-        <code>apm.yml</code>, deletes the fragments it consumed, commits
-        <code>chore(release): X.Y.Z</code>, and dispatches <code>release.yml</code> to cut the tag and
-        the GitHub Release. A pull request with no fragment (the <code>skip-changelog</code> label)
-        touches nothing and releases nothing.
+        <strong>Releases are cut by hand.</strong> Merging a pull request that carries a fragment
+        pushes it to <code>.changes/unreleased/</code> on <code>main</code> and releases nothing.
+        Nothing releases on a timer either. When the pending batch is ready, you dispatch
+        <strong>Release Prep</strong>, which ships it as one version: it resolves the level, prepends
+        the CHANGELOG section with the consumer-install block and the link reference, writes
+        <code>version:</code> into <code>apm.yml</code>, deletes the fragments it consumed, commits
+        <code>chore(release): X.Y.Z</code>, dispatches <code>release.yml</code> to cut the tag and the
+        GitHub Release, and retires the pre-release.
       </p>
       <p>
-        Run <strong>Release Prep</strong> manually only to overrule the level, to pin an exact version,
-        or to flush fragments that reached <code>main</code> without triggering it. Tick <em>dry run</em>
-        first to see the resolved version and the assembled section without committing anything.
+        That makes releasing a judgement about readiness rather than a date. A quick fix ships as soon
+        as you have verified it in the preview; a larger change sits in preview until it is ready, and
+        anything merged in the meantime rides along with it.
+      </p>
+      <p>
+        <strong>Between releases, <code>main</code> is installable.</strong> Every merge triggers
+        <strong>Rolling Preview</strong>, which renders the pending fragments into a single GitHub
+        pre-release tagged with the version they resolve to (<code>v0.15.0-pre</code>) and force-moves
+        that tag to the new head. It only reads: no fragment is consumed, no version is bumped, and
+        <code>CHANGELOG.md</code> is untouched. Exactly one pre-release is open at a time, so when a
+        <code>minor</code> fragment lands the old one is deleted and the new name takes over.
+        A pull request with no fragment (the <code>skip-changelog</code> label) contributes no bump.
+      </p>
+      <p>
+        Tick <em>dry run</em> when you dispatch to see the resolved version and the assembled section
+        without committing anything. Use the <code>bump</code> and <code>version</code> inputs to
+        overrule the level the fragments resolved to or to pin an exact number.
       </p>
       <p>To do it locally instead:</p>
       <pre><code>apm run release-prep                        # resolve version, assemble, write

--- a/scripts/Invoke-ReleasePrep.ps1
+++ b/scripts/Invoke-ReleasePrep.ps1
@@ -47,10 +47,19 @@
     Print the assembled section and resolved version without writing anything.
 .PARAMETER GitHubOutput
     Append 'version', 'previous_version', and 'has_changes' to $env:GITHUB_OUTPUT.
+.PARAMETER SectionOutFile
+    Also write the assembled section to this path. Honoured under -DryRun, which
+    is how the rolling pre-release renders the notes for the release currently
+    accumulating on main without consuming the fragments.
+.PARAMETER InstallRef
+    Tag the consumer-install snippet and link reference point at. Defaults to
+    'v<newVersion>'. The pre-release passes its own rolling tag.
 .EXAMPLE
     ./scripts/Invoke-ReleasePrep.ps1
 .EXAMPLE
     ./scripts/Invoke-ReleasePrep.ps1 -DryRun
+.EXAMPLE
+    ./scripts/Invoke-ReleasePrep.ps1 -DryRun -SectionOutFile notes.md -InstallRef v0.14.0-pre
 .EXAMPLE
     ./scripts/Invoke-ReleasePrep.ps1 -Version 1.0.0
 .EXAMPLE
@@ -99,7 +108,15 @@ param(
     [switch]$DryRun,
 
     [Parameter(Mandatory = $false)]
-    [switch]$GitHubOutput
+    [switch]$GitHubOutput,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$SectionOutFile,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$InstallRef
 )
 
 $ErrorActionPreference = 'Stop'
@@ -194,8 +211,13 @@ function New-ChangelogSection {
         [pscustomobject[]]$Fragments,
 
         [Parameter(Mandatory = $false)]
-        [string]$Additional
+        [string]$Additional,
+
+        [Parameter(Mandatory = $false)]
+        [string]$Ref
     )
+
+    if (-not $Ref) { $Ref = "v$NewVersion" }
 
     $lines = [System.Collections.Generic.List[string]]::new()
     $lines.Add("## [$NewVersion] - $Date")
@@ -219,10 +241,10 @@ function New-ChangelogSection {
     $lines.Add('Pin to this version:')
     $lines.Add('')
     $lines.Add('```powershell')
-    $lines.Add("apm install `"$RepoSlug#v$NewVersion`"")
+    $lines.Add("apm install `"$RepoSlug#$Ref`"")
     $lines.Add('```')
     $lines.Add('')
-    $lines.Add("[$NewVersion]: https://github.com/$RepoSlug/releases/tag/v$NewVersion")
+    $lines.Add("[$NewVersion]: https://github.com/$RepoSlug/releases/tag/$Ref")
     $lines.Add('')
 
     return ($lines -join "`n")
@@ -279,7 +301,11 @@ if ($changelog -match "(?m)^## \[$([regex]::Escape($newVersion))\]") {
     throw "CHANGELOG.md already documents $newVersion. Pass -Version to target a different release."
 }
 
-$section = New-ChangelogSection -NewVersion $newVersion -Date $ReleaseDate -Fragments $fragments -Additional $ExtraEntry
+$section = New-ChangelogSection -NewVersion $newVersion -Date $ReleaseDate -Fragments $fragments -Additional $ExtraEntry -Ref $InstallRef
+
+if ($SectionOutFile) {
+    Set-Content -LiteralPath $SectionOutFile -Value $section -Encoding utf8NoBOM
+}
 
 Write-Host "Version:   $currentVersion -> $newVersion ($resolvedBump)" -ForegroundColor Cyan
 Write-Host "Fragments: $($fragments.Count)" -ForegroundColor Cyan


### PR DESCRIPTION
## Summary

Merging no longer cuts a release. Fragments accumulate on `main` and stay installable through a single rolling pre-release; a maintainer ships them when they are ready by dispatching **Release Prep**.

Today the chain is fully automatic: a fragment landing on `main` triggers `release-prep.yml`, whose commit trips `release.yml`, and `sync-hve-core.yml` cuts a release of its own every morning the upstream pin moves. Three releases in two days, and nothing is ever installed before it ships.

## Type of change

- [x] Feature / new content
- [ ] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Change fragment

- [x] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [x] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [x] Its body reads as final release notes, not as a commit message
- [x] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

`minor` because how the package is released and consumed changes: there is a new installable channel and merging stops shipping.

## Shared learning sanitization (if proposing a learning)

Not applicable — no `shared-learnings.md` changes.

## What changes

| File | Change |
|---|---|
| `.github/workflows/release-prep.yml` | `workflow_dispatch` only. Gains a `ref` input and retires the pre-release after a release from `main`. |
| `.github/workflows/preview.yml` | **New.** On every merge to `main`, renders pending fragments into one pre-release tagged `v<next>-pre` and force-moves that tag. Read-only. |
| `.github/workflows/sync-hve-core.yml` | Records a pin move as a change fragment instead of assembling and dispatching a release. Cast-delta guard and Watch Mode handoff unchanged. |
| `.github/workflows/release.yml` | Gains a `ref` input; tags from the checked-out SHA; declines the Latest badge when the version being cut is lower than the current latest. |
| `.github/workflows/pr-validation.yml` | Accepts a `release-merge-back` label so a hotfix can merge back carrying release state. Corrected job summary. |
| `scripts/Invoke-ReleasePrep.ps1` | Adds `-SectionOutFile` and `-InstallRef` so the preview reuses the real renderer without consuming fragments. |
| `README.md`, `CONTRIBUTING.md`, `.changes/README.md`, `docs/` | Document the preview channel, on-demand releases, and the hotfix path. |

## Notes

**The preview only reads.** `Invoke-ReleasePrep.ps1 -DryRun` consumes no fragment, bumps no version, and does not touch `CHANGELOG.md`. The contributor workflow is unchanged: add a fragment, open a PR.

**Verified before building this:**

- Unpinned squad self-references resolve to the *parent package's ref*, not to `main` — a test install of `#v0.11.0` locked `resolved_ref: v0.11.0`. A pre-release tag is therefore self-consistent, and no `-SquadRef` pinning is needed.
- Pre-releases can never take the **Latest** badge (GitHub: *"the most recent non-prerelease, non-draft release"*; *"drafts and prereleases cannot be set as latest"*). `v0.14.0` keeps it until a real release is cut.
- `apm install` with **no** ref resolves to `main`'s HEAD, not to the latest release, and APM warns about drift. Unrelated to this PR, but it is why the docs always show a pinned ref.
- All five workflows parse.

**A release ships a commit, not a selection of fragments.** A tag cut from `main` contains everything merged into `main`, whatever the CHANGELOG lists. So when `main` holds work that must not ship yet, a fix is released from a hotfix branch cut off the last release tag via the new `ref` input — documented under *Shipping a fix without shipping everything else* in `CONTRIBUTING.md`.

**On merge, this bootstraps itself:** `preview.yml` fires immediately and should publish `v0.15.0-pre` (a `minor` fragment on top of `0.14.0`). That first pre-release is the acceptance test. Nothing auto-releases after that.

**Known gap, not in this PR:** there is still no automated install smoke test. Nothing in CI ever runs `apm install`. That matters more now that the pre-release is the thing people install, and it is the natural follow-up.
