### PR TITLE
docs: cover the hotfix path and preview channel on the site

### DIFF
--- a/.changes/unreleased/20260814-document-the-hotfix-path-and-preview-channel.md
+++ b/.changes/unreleased/20260814-document-the-hotfix-path-and-preview-channel.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: Changed
+---
+
+- **The published docs did not describe how a fix ships without shipping everything else.** Added the hotfix procedure, the `ref` release input, and the `release-merge-back` label to the contributing and maintaining pages, and documented the rolling pre-release channel on getting started and troubleshooting.

--- a/docs/contributing.html
+++ b/docs/contributing.html
@@ -134,9 +134,46 @@ type: Fixed
         The exact tag is on the
         <a href="https://github.com/Peter-N91/hve-squad/releases">Releases page</a>, marked as a
         pre-release. It is a channel rather than a fixed point: the tag moves on every merge, and it is
-        renamed when a <code>minor</code> fragment lands midweek. Pin a released version for anything
+        renamed when a <code>minor</code> fragment lands. Pin a released version for anything
         you depend on. The full format reference lives in
         <a href="https://github.com/Peter-N91/hve-squad/blob/main/.changes/README.md">.changes/README.md</a>.
+      </p>
+
+      <h2>Shipping a fix without shipping everything else</h2>
+      <p>
+        A release ships a <strong>commit</strong>, not a selection of fragments. The tag is cut from the
+        branch head, so a release from the default branch contains everything merged into it, whatever
+        the CHANGELOG happens to list. Choosing which fragments to consume changes the release notes,
+        not the code. That leaves two cases, and only the second needs anything unusual.
+      </p>
+      <p>
+        <strong>The default branch is shippable.</strong> A maintainer dispatches Release Prep and your
+        fix goes out with everything else pending, as one version. If a pending fragment asked for
+        <code>minor</code>, that version is a minor &mdash; and it still contains your patch, so
+        consumers get the fix. This is almost always the right answer.
+      </p>
+      <p>
+        <strong>The default branch holds something that must not ship yet.</strong> Then a release from
+        it would carry that work out alongside the fix, so the fix has to come from somewhere that does
+        not contain it: a hotfix branch cut off the last release tag.
+      </p>
+      <pre><code>git switch --detach v0.14.0
+git switch -c hotfix/v0.14.1
+# apply the fix, then record it
+apm run change            # Type: Fixed, Bump: patch
+git push -u origin hotfix/v0.14.1</code></pre>
+      <p>
+        A maintainer then dispatches <strong>Release Prep</strong> with <code>ref</code> set to the
+        hotfix branch. It assembles the CHANGELOG from that branch's fragments only, bumps
+        <code>apm.yml</code> to <code>0.14.1</code>, and cuts the tag from that branch. The rolling
+        pre-release on the default branch is left alone, because the batch it describes is still
+        pending. The hotfix branch is then merged back with the <code>release-merge-back</code> label,
+        which is what allows that pull request to carry the release state Release Prep already wrote.
+      </p>
+      <p>
+        A hotfix released after a higher version does not steal the <strong>Latest</strong> badge: the
+        release workflow compares versions and declines it when the tag is lower than the current
+        latest.
       </p>
 
       <h2>Proposing a shared learning</h2>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -134,6 +134,13 @@ targets:
       </p>
       <pre><code>apm install "Peter-N91/hve-squad#vX.Y.z" --target copilot</code></pre>
       <p>
+        To try something that has been merged but not released yet, install the rolling pre-release
+        instead &mdash; <code>apm install "Peter-N91/hve-squad#vX.Y.z-pre"</code>. Its exact tag is on
+        the <a href="https://github.com/Peter-N91/hve-squad/releases">Releases page</a>, marked as a
+        pre-release. The tag moves on every merge, so use it to test and pin a released version for
+        anything you depend on.
+      </p>
+      <p>
         <code>apm install</code> re-flattens the package into <code>.github/</code>. Your squad
         <strong>state</strong> under <code>.copilot-tracking/squad/</code> is created per-project and
         is never packaged, so re-installing does not overwrite your roster, routing, decisions, or

--- a/docs/maintaining.html
+++ b/docs/maintaining.html
@@ -472,9 +472,31 @@ pwsh -File scripts/Invoke-ReleasePrep.ps1 -Version 1.0.0        # exact number, 
         Tick <em>dry run</em> when you dispatch to see the resolved version and the assembled section
         without committing anything. Use the <code>bump</code> and <code>version</code> inputs to
         overrule the level the fragments resolved to or to pin an exact number.
+      </Do not keep a long-lived <code>release</code> branch. Cut a short-lived
+        <code>hotfix/vX.Y.Z</code> branch off an existing tag only when <code>main</code> holds work
+        that must not ship yet and a fix cannot wait for it &mdash; a release ships a commit, so a tag
+        cut from <code>main</code> carries that pending work out with the fix.
       </p>
-      <p>To do it locally instead:</p>
-      <pre><code>apm run release-prep                        # resolve version, assemble, write
+      <pre><code>git switch --detach v0.14.0
+git switch -c hotfix/v0.14.1
+# apply the fix, then record it
+apm run change            # Type: Fixed, Bump: patch
+git push -u origin hotfix/v0.14.1</code></pre>
+      <p>
+        Dispatch <strong>Release Prep</strong> with <code>ref</code> set to <code>hotfix/v0.14.1</code>.
+        It consumes only that branch's fragments, bumps <code>apm.yml</code> there, and cuts the tag
+        from that branch; <code>release.yml</code> receives the same ref and tags the commit it checked
+        out. The rolling pre-release is deliberately <em>not</em> retired, because the batch it
+        describes is still pending on <code>main</code>.
+      </p>
+      <p>
+        Merge the branch back afterwards so the fix survives the next release, and label that pull
+        request <code>release-merge-back</code>. That label is the only exemption to the
+        <code>CHANGELOG.md</code> and <code>version:</code> guards in <code>pr-validation.yml</code>,
+        and it exists precisely because Release Prep &mdash; not a human &mdash; wrote both. If a
+        higher version has already shipped, the release workflow compares versions and passes
+        <code>--latest=false</code>, so the hotfix does not take the <strong>Latest</strong> badge from
+        the release that supersedes itrelease-prep                        # resolve version, assemble, write
 pwsh -File scripts/Invoke-ReleasePrep.ps1 -DryRun           # preview only
 pwsh -File scripts/Invoke-ReleasePrep.ps1 -Bump minor       # overrule the fragments
 pwsh -File scripts/Invoke-ReleasePrep.ps1 -Version 1.0.0    # force an exact version</code></pre>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -168,6 +168,9 @@ $env:PATH = "C:\Program Files\Graphviz\bin;$env:PATH"</code></pre>
         <li>Releases follow <a href="https://semver.org/">Semantic Versioning</a>.</li>
         <li>See <a href="https://github.com/Peter-N91/hve-squad/blob/main/CHANGELOG.md">CHANGELOG.md</a> for what is included in each version.</li>
         <li>Consumers can pin to a tagged version, for example <code>apm install "Peter-N91/hve-squad#vX.Y.z"</code>.</li>
+        <li>Releases are cut by hand when the pending work is judged ready, not on a schedule.</li>
+        <li>Between releases, everything already merged is installable from a rolling pre-release: <code>apm install "Peter-N91/hve-squad#vX.Y.z-pre"</code>. That tag moves on every merge, so it is for testing rather than for anything you depend on. A pre-release never shows as <strong>Latest</strong>.</li>
+        <li>Installing with no ref at all resolves to the default branch, not to the latest release, and APM warns about the drift. Always pin.</li>
       </ul>
 
       <h2>Notes</h2>


### PR DESCRIPTION
## Summary

Completes the documentation for the release model that shipped in #68. The site was missing the hotfix path entirely — it existed in `CONTRIBUTING.md` but never reached `docs/`.

## Type of change

- [ ] Feature / new content
- [ ] Fix
- [x] Docs only
- [ ] Chore / maintenance

## Change fragment

- [x] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [x] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [x] Its body reads as final release notes, not as a commit message
- [x] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

`patch` — this documents an idea that already has a pending `minor` fragment from #68; it adds no new concept of its own.

## Shared learning sanitization (if proposing a learning)

Not applicable — no `shared-learnings.md` changes.

## What changes

| Page | Added |
|---|---|
| `docs/contributing.html` | The whole *Shipping a fix without shipping everything else* section, including why a release ships a commit rather than a selection of fragments |
| `docs/maintaining.html` | Replaced the stale *avoid a long-lived release branch* note with the concrete hotfix procedure, the `ref` dispatch input, and the `release-merge-back` label |
| `docs/troubleshooting.html` | Versioning: releases are cut by hand, the `-pre` channel, and that a pre-release never shows as **Latest** |
| `docs/getting-started.html` | How to install the rolling pre-release when updating |

Also removes a leftover "midweek" from an earlier iteration of the design that assumed a weekly schedule.

## Notes

No behavior change — documentation only. Nothing under `.github/workflows/`, `scripts/`, or `squad-src/` is touched.

These four files were originally committed to the #68 branch after that PR had already been squash-merged, so the commit was orphaned and never reached `main`. This PR replays it on top of current `main`; the cherry-pick applied cleanly with no conflicts.

For the record, #68 bootstrapped correctly on merge: `v0.15.0-pre` was published against `f501912`, and `v0.14.0` still holds the **Latest** badge.
