### PR TITLE
fix(workflows): pin squad self-references into the release tag

### DIFF
--- a/.changes/unreleased/20260818-pin-squad-self-references-at-release.md
+++ b/.changes/unreleased/20260818-pin-squad-self-references-at-release.md
@@ -1,0 +1,13 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **Every release tag served squad files from `main` instead of from the tag.** The 47
+  `Peter-N91/hve-squad` entries in `apm.yml` ship as bare paths, and APM resolves a bare path against
+  the default branch — so a tag froze the dependency list but not its contents. Measured by installing
+  `#v0.14.0` and getting `main`'s coordinator back, while the hve-core entries in the same manifest
+  resolved correctly because they carry `#<sha>`. `release.yml` now pins the self-references to the tag
+  it is cutting and pushes that commit straight to `refs/tags/`, so a release installs the files it was
+  built from (`.github/workflows/release.yml`, `scripts/Set-SquadSelfRefPin.ps1`). `main` keeps the
+  unpinned manifest, so development installs still track `main`. Tags before v0.15.2 remain unpinned.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,7 +125,33 @@ jobs:
           fi
           printf '%s' "$NOTES" > /tmp/release_notes.md
 
-      # ── Create GitHub Release (also creates the tag) ────────────
+      # ── Pin squad self-references, then tag that commit ──────────────────
+      #    The 47 Peter-N91/hve-squad entries in apm.yml ship as bare paths, and
+      #    APM resolves a bare path against the default branch. Without this step a
+      #    tag freezes the dependency *list* but not its *contents*: installing
+      #    '#v0.14.0' was measured returning main's coordinator, while the hve-core
+      #    entries in the same manifest resolved correctly because they carry '#<sha>'.
+      #
+      #    The manifest cannot name its own tag before the tag exists, so the pin
+      #    lands in a commit pushed straight to refs/tags and never to main. main
+      #    keeps the unpinned manifest, so development installs still track main.
+      - name: Pin squad self-references and create the tag
+        if: steps.tag_check.outputs.exists == 'false'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.version.outputs.tag }}
+        run: |
+          pwsh -File scripts/Set-SquadSelfRefPin.ps1 -ApmFile apm.yml -Ref "$TAG"
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git remote set-url origin \
+            "https://x-access-token:${GITHUB_TOKEN}@github.com/${{ github.repository }}.git"
+          git add apm.yml
+          git commit -m "chore(release): pin squad self-references to $TAG"
+          git push origin "HEAD:refs/tags/$TAG"
+          echo "::notice::Tagged $TAG at a pinned manifest; main is unchanged."
+
+      # ── Create GitHub Release (the tag already exists) ────────────
       - name: Create GitHub Release
         if: steps.tag_check.outputs.exists == 'false'
         env:
@@ -138,7 +164,6 @@ jobs:
             "$TAG"
             --title "$TAG"
             --notes-file /tmp/release_notes.md
-            --target "$GITHUB_SHA"
           )
           [[ "$DRAFT" == "true" ]] && ARGS+=(--draft)
 

--- a/docs/maintaining.html
+++ b/docs/maintaining.html
@@ -324,18 +324,41 @@ flowchart TD
       <ul>
         <li><code>SquadSourceRoot</code>: local path to the squad source tree (default: <code>squad-src</code>). If the path does not exist, squad enumeration is skipped without error.</li>
         <li><code>SquadRepoSlug</code>: <code>owner/repo</code> that hosts the squad source (default: <code>Peter-N91/hve-squad</code>).</li>
-        <li><code>SquadRef</code>: optional git ref (the release tag you are cutting, e.g. <code>vX.Y.Z</code>) that pins the squad self-references as <code>#&lt;ref&gt;</code>. Omit it during development so local installs keep resolving; supply it at release time.</li>
+        <li><code>SquadRef</code>: optional git ref that pins the squad self-references as <code>#&lt;ref&gt;</code>. You normally leave this alone &mdash; <strong>the Release workflow pins automatically</strong> (see <em>Reproducible release tags</em> below). It remains available for pinning a manifest by hand.</li>
       </ul>
       <p>Use <code>-DryRun</code> to preview both the hve-core and squad entries without writing <code>apm.yml</code>.</p>
+
+      <h3>Reproducible release tags</h3>
+      <p>
+        The squad self-references ship as bare paths on <code>main</code>, and APM resolves a bare path
+        against the default branch. Left alone, a tag would freeze the dependency <em>list</em> but not
+        its <em>contents</em>: installing <code>#v0.14.0</code> was measured returning
+        <code>main</code>'s coordinator, while the hve-core entries in the same manifest resolved
+        correctly because they carry <code>#&lt;sha&gt;</code>. APM warns about it directly &mdash;
+        <code>47 dependencies unpinned: Peter-N91/hve-squad</code>.
+      </p>
+      <p>
+        <code>release.yml</code> closes this without any manual step. Before creating the release it runs
+        <code>scripts/Set-SquadSelfRefPin.ps1 -Ref vX.Y.Z</code>, commits the pinned manifest, and pushes
+        that commit <strong>straight to <code>refs/tags/vX.Y.Z</code></strong>. A manifest cannot name its
+        own tag before the tag exists, so the pin lives in a commit that only the tag points at.
+        <code>main</code> never receives it and keeps the unpinned manifest, so development installs
+        continue to track <code>main</code>.
+      </p>
+      <div class="callout warn">
+        <p>
+          This applies from <strong>v0.15.2</strong> onward. Every earlier tag resolves its squad files
+          from <code>main</code> and is not reproducible. Fixing one retroactively means force-moving
+          its tag, which changes what its GitHub Release points at.
+        </p>
+      </div>
 
       <div class="callout">
         <p>
           <code>apm lock</code> and <code>apm install</code> can only resolve the squad virtual paths
           once the <code>squad-src/</code> tree has been pushed to the <code>SquadRepoSlug</code> remote.
-          When squad entries are pinned with <code>-SquadRef vX.Y.Z</code>, that tag must also exist on
-          the remote, so pin the squad references as part of cutting the release (commit, then create
-          the tag) and verify <code>apm install</code> from a fresh clone of the tag rather than the
-          working tree.
+          Release tags are pinned automatically by <code>release.yml</code>, so verify
+          <code>apm install</code> from a fresh clone of the tag rather than from the working tree.
         </p>
       </div>
 
@@ -501,12 +524,10 @@ pwsh -File scripts/Invoke-ReleasePrep.ps1 -DryRun           # preview only
 pwsh -File scripts/Invoke-ReleasePrep.ps1 -Bump minor       # overrule the fragments
 pwsh -File scripts/Invoke-ReleasePrep.ps1 -Version 1.0.0    # force an exact version</code></pre>
       <p>
-        Before a release that also re-pins dependencies, regenerate the list first:
-        <code>pwsh -File scripts/Update-ApmDependencies.ps1 -Ref main -SquadRef vX.Y.Z</code> pins every
-        hve-core entry to <code>main</code>'s commit SHA and the squad self-references to
-        <code>vX.Y.Z</code>. Refresh the lockfile with <code>apm lock</code>. Because
-        <code>-SquadRef</code> names a tag that does not exist yet, verify <code>apm install</code>
-        from a fresh clone of the tag after it is pushed, not from the working tree.
+        Before a release that also re-pins hve-core, regenerate the list first:
+        <code>pwsh -File scripts/Update-ApmDependencies.ps1 -Ref main</code> pins every hve-core entry to
+        <code>main</code>'s commit SHA. Refresh the lockfile with <code>apm lock</code>. The squad
+        self-references need no action &mdash; <code>release.yml</code> pins them into the tagged commit.
       </p>
       <p>
         Avoid a long-lived <code>release</code> branch. Only create <code>release/vX.Y.Z</code> from an

--- a/scripts/Set-SquadSelfRefPin.ps1
+++ b/scripts/Set-SquadSelfRefPin.ps1
@@ -1,0 +1,107 @@
+#!/usr/bin/env pwsh
+# Copyright (c) 2026 Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+#Requires -Version 7.4
+
+<#
+.SYNOPSIS
+    Pins this package's own squad self-references in apm.yml to a git ref.
+.DESCRIPTION
+    Every dependency in apm.yml that points back at this repository
+    (Peter-N91/hve-squad/squad-src/...) ships as a bare path with no '#ref'.
+    APM resolves a bare path against the repository's default branch, so a
+    release tag freezes the dependency *list* but not the dependency *contents*:
+    installing an old tag delivers today's squad files.
+
+    Measured 2026-08-18: installing '#v0.14.0' returned main's coordinator, while
+    the hve-core entries in the same manifest — which do carry '#<sha>' — resolved
+    correctly to the pinned commit. APM itself warns
+    '47 dependencies unpinned: Peter-N91/hve-squad -- add #tag or #sha to prevent drift'.
+
+    This script appends '#<Ref>' to those entries and nothing else. It is
+    deliberately separate from Update-ApmDependencies.ps1, which reaches the same
+    result via -SquadRef but must clone hve-core to enumerate it first. At release
+    time the manifest is already correct and only needs the suffix, so an offline,
+    deterministic rewrite is the safer operation.
+
+    Entries that already carry a ref are left untouched, so the script is
+    idempotent. hve-core entries are never modified.
+.PARAMETER ApmFile
+    Path to the apm.yml to rewrite.
+.PARAMETER Ref
+    Git ref to pin to — normally the release tag being cut, for example 'v0.16.0'.
+.PARAMETER RepoSlug
+    Repository slug whose self-references are pinned.
+.PARAMETER DryRun
+    Report what would change without writing the file.
+.EXAMPLE
+    ./scripts/Set-SquadSelfRefPin.ps1 -Ref v0.16.0
+.EXAMPLE
+    ./scripts/Set-SquadSelfRefPin.ps1 -Ref v0.16.0 -DryRun
+.NOTES
+    Runs in release.yml against the commit the tag will point at. That commit is
+    intentionally not pushed to main: main keeps the unpinned manifest so
+    development installs continue to track main.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$ApmFile = 'apm.yml',
+
+    [Parameter(Mandatory = $true)]
+    [ValidateNotNullOrEmpty()]
+    [string]$Ref,
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$RepoSlug = 'Peter-N91/hve-squad',
+
+    [Parameter(Mandatory = $false)]
+    [switch]$DryRun
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $ApmFile)) {
+    throw "Manifest not found: $ApmFile"
+}
+
+if ($Ref -match '[\s#]') {
+    throw "Ref '$Ref' contains whitespace or '#'."
+}
+
+$lines = Get-Content -LiteralPath $ApmFile
+$pattern = '^(?<indent>\s*-\s+)(?<path>' + [regex]::Escape($RepoSlug) + '/\S+)$'
+
+$pinned = 0
+$alreadyPinned = 0
+
+$updated = foreach ($line in $lines) {
+    if ($line -match $pattern) {
+        if ($Matches['path'] -like '*#*') {
+            $alreadyPinned++
+            $line
+        }
+        else {
+            $pinned++
+            "$($Matches['indent'])$($Matches['path'])#$Ref"
+        }
+    }
+    else {
+        $line
+    }
+}
+
+if ($pinned -eq 0 -and $alreadyPinned -eq 0) {
+    throw "No $RepoSlug self-references found in $ApmFile. Refusing to write a manifest this script does not understand."
+}
+
+if ($DryRun) {
+    Write-Host "[dry run] would pin $pinned entries to #$Ref ($alreadyPinned already pinned)." -ForegroundColor Yellow
+    return
+}
+
+Set-Content -LiteralPath $ApmFile -Value $updated
+Write-Host "Pinned $pinned $RepoSlug entries to #$Ref ($alreadyPinned already pinned)." -ForegroundColor Green


### PR DESCRIPTION
## Summary

Every release tag this package has ever cut serves squad files from `main`, not from the tag. 87 tags, zero pinned self-references. This fixes it from the next release onward.

## Type of change

- [ ] Feature / new content
- [x] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Change fragment

- [x] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [x] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [x] Its body reads as final release notes, not as a commit message
- [x] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

`20260818-pin-squad-self-references-at-release.md` — `Fixed` / `patch`.

## Shared learning sanitization (if proposing a learning)

N/A — this PR does not touch `shared-learnings.md`.

## The defect, measured

The 47 `Peter-N91/hve-squad` entries in `apm.yml` ship as bare paths with no `#ref`. APM resolves a bare path against the repository's default branch.

I installed `Peter-N91/hve-squad#v0.14.0` into a scratch directory. The deployed coordinator contains *"Ten squad instruction files define the data…"* — a line that exists only in v0.15.1, **not** in v0.14.0. The tag delivered `main`'s content.

APM says so itself, in the same run:

```
[!] 46 dependencies unpinned: Peter-N91/hve-squad -- add #tag or #sha to prevent drift
```

The same install is also the control. The 242 `microsoft/hve-core` entries in that manifest carry `#<sha>`, and they resolved to the pinned commit, ignoring main. Confirmed again on `v0.15.1`, where the resolution log showed **688 references to the tag's pinned hve-core SHA and 0 to main's newer one**.

So: one manifest, one resolver, two outcomes. The only difference is the `#ref` suffix.

**A tag freezes the dependency *list*. Only a `#ref` freezes the dependency *contents*.**

## The fix

`release.yml` now runs `scripts/Set-SquadSelfRefPin.ps1 -Ref vX.Y.Z` before creating the release, commits the pinned manifest, and pushes that commit **straight to `refs/tags/vX.Y.Z`**.

The tagged commit is deliberately **not on `main`**. That is what resolves the chicken-and-egg: a manifest cannot name its own tag before the tag exists, and `main` must stay unpinned or development installs would freeze to the last release. Putting the pin in a commit that only the tag points at satisfies both.

`gh release create` no longer passes `--target`, since the tag now exists before the release is created.

### Why a new script rather than `-SquadRef`

`Update-ApmDependencies.ps1 -SquadRef` reaches the same result, but it must clone hve-core to enumerate the manifest first. At release time the manifest is already correct and only needs a suffix appended, so an offline deterministic rewrite is the safer operation in CI — and it cannot accidentally move the hve-core pins, which is a documented past hazard in this repo.

## Testing

The script was run against a copy of the real `apm.yml`:

| Check | Result |
|---|---|
| Entries pinned | **47** — matches APM's own warning count |
| Idempotent (second run) | `0 pinned, 47 already pinned` |
| Lines changed | **94** = 47 removed + 47 added |
| Non-squad lines touched | **0** — hve-core pins byte-identical |
| Malformed ref (`with space`, `with#hash`) | rejected |
| Manifest with no squad entries | throws rather than writing |

Both changed files lint clean.

**Not tested end-to-end.** The workflow path only executes during a real release. The risk concentrates in one line — `git push origin "HEAD:refs/tags/$TAG"` — and the first release after merge is the real test. `tag_check` still guards against a tag that already exists, so a re-run is safe.

## Notes

**This fixes releases from v0.15.2 onward. It does not fix history.** All 87 existing tags stay unpinned. Fixing one retroactively means force-moving its tag, which changes what its GitHub Release points at and breaks any lockfile pinned to the old SHA — worth doing for `v0.15.1` alone, perhaps, and not worth it for the rest.

**Pre-releases need no pin.** `preview.yml` force-moves the `-pre` tag to `main`'s head, and unpinned refs resolve to `main` — the same commit. That is why this never surfaced on `-pre`, and why pinning `main` would be actively harmful: the `-pre` tag is renamed whenever the resolved version changes, so a hardcoded pre-tag pin in `main` would send a later pre-release back to an older commit.

**Releases from v0.1.0 – v0.6.0 are unfixable anyway.** Their hve-core entries are also unpinned, and upstream has since consolidated files they reference.

**Where the wrong answer came from.** `.copilot-tracking/pr/pr-body-release-on-demand.md` claims unpinned self-references resolve to the parent package's ref, citing a test install of `#v0.11.0`. That claim is wrong — it most likely read the lockfile's record of the root package rather than the deployed content. The repository memory had it right in three separate places. Worth deleting or correcting that note so it does not mislead again.
