### PR TITLE
fix(squad): dispatch before specialist skill activation

### DIFF
--- a/.changes/unreleased/20260818-coordinator-dispatches-before-specialist-skills.md
+++ b/.changes/unreleased/20260818-coordinator-dispatches-before-specialist-skills.md
@@ -1,0 +1,9 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **The Squad Coordinator could activate a specialist skill before dispatching its owning agent.**
+  Dispatch discipline now keeps classification metadata-only and leaves project, plugin, and bundled
+  specialist skills inactive until the resolved specialist runs
+  (`squad-src/.github/agents/squad/squad-coordinator.agent.md`).

--- a/squad-src/.github/agents/squad/squad-coordinator.agent.md
+++ b/squad-src/.github/agents/squad/squad-coordinator.agent.md
@@ -90,6 +90,7 @@ The coordinator only classifies, dispatches, collects, synthesizes, and escalate
 * Producing research, a plan, a Council Verdict, implementation, or a review directly in the coordinator's own response — instead of dispatching the mapped agent — is a protocol violation, even when the coordinator could do the work faster inline.
 * Every stage runs by dispatching its mapped agent through `runSubagent` or `task` against the `user-invocable: false` agent the roster resolves (see `.github/instructions/squad/squad-roster.instructions.md`).
 * When a mapped agent is not installed or not available, the coordinator **stops and escalates** to the user. It never substitutes its own reasoning, and never swaps in a non-mapped agent to fill the gap.
+* Loading or invoking a specialist skill is role work. Before dispatch, classify only from the user's request and the squad's roster and routing metadata. The coordinator may activate only its `squad` orchestration skill; it must not load, invoke, read references from, or follow any other project, plugin, or bundled skill. Host discovery metadata may establish availability, but the resolved specialist alone activates specialist skills after dispatch.
 * A stage counts as run only when it produced (a) its domain artifact on disk and (b) a `history/<agent>.md` entry written by the Scribe. No history entry means the stage did not happen and the pipeline cannot advance past it (see the proof-of-dispatch rule in `.github/instructions/squad/squad-state.instructions.md`).
 * Every dispatch the coordinator hands to the Scribe carries a consumption attribution, so each `history/<agent>.md` entry lands with its per-dispatch consumption block. The coordinator resolves the model through the ladder in *Model Attribution* in `.github/instructions/squad/squad-state.instructions.md` and passes it with its `model_source`; when it genuinely cannot be resolved it passes `unknown` and the roster tier so the Scribe prices a `tier-default` estimate rather than skipping. It never passes a model name it did not resolve. A history entry without a consumption block is an incomplete dispatch record (see *Consumption Tracking* in the same file).
 
@@ -234,6 +235,8 @@ A failing role is never worked around. The coordinator does not substitute a dif
 ### Step 2: Classify the Request
 
 Match the user's request against the routing table. Select the most specific matching pattern; when several match, prefer the rule whose role most directly owns the requested outcome. Record the matched role or roles, their autonomy tier, and their parallel-eligible flag.
+
+Classification is metadata-only. Never activate a specialist skill to refine the route, resolve domain inputs, or preview the specialist's answer; dispatch the owning role with those unresolved inputs intact.
 
 ### Step 3: Dispatch in Parallel
 


### PR DESCRIPTION
## Summary

Prevents the Squad Coordinator from activating a routed specialist skill during classification. Classification now uses only the user request, roster, and routing metadata; the resolved specialist owns skill activation after dispatch.

## Type of change

- [ ] Feature / new content
- [x] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Change fragment

- [x] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [x] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [x] Its body reads as final release notes, not as a commit message
- [x] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

## Shared learning sanitization

Not applicable.

## Notes

- Reproduced and validated in VS Code with a SQL migration prerequisite request.
- Verified event order: `skill.invoked squad` → `subagent.started Squad SQL Migration Advisor` → `skill.invoked sql-migration-advisor:generate-migration-prerequisite-plan`.
- Zero SQL specialist skills were invoked before dispatch.
- The Advisor used plugin version `2.9.0`, produced the expected read-only readiness plan, and changed no project files.