### PR TITLE
fix(tests): quote the prompt the Tier 1 harness hands the Copilot CLI

### DIFF
--- a/.changes/unreleased/20260820-tier1-harness-quotes-its-prompt.md
+++ b/.changes/unreleased/20260820-tier1-harness-quotes-its-prompt.md
@@ -1,0 +1,12 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **The Tier 1 behaviour harness could not start a squad turn.** `Start-Process` concatenates its
+  argument list with spaces and does no quoting of its own, so the scenario prompt reached the
+  Copilot CLI as a stream of separate words and every turn exited on `Invalid command format` in
+  under a second. The failure sat exactly in the gap the harness's own `-ProvisionOnly` mode skips,
+  which is why provisioning had passed on all three scenarios while no scenario had ever run a turn.
+  Arguments carrying whitespace now bring their own quotes, following the Windows argv rules
+  PowerShell also applies when it tokenizes the string on Unix (`tests/tier1/SquadRun.psm1`).

--- a/tests/tier1/SquadRun.psm1
+++ b/tests/tier1/SquadRun.psm1
@@ -82,6 +82,30 @@ function New-SquadWorkspace {
     $install
 }
 
+function ConvertTo-ProcessArgument {
+    <#
+    .SYNOPSIS
+        Quotes one argument so a joined argument string survives as a single token.
+    .DESCRIPTION
+        Start-Process concatenates its argument list with spaces and does no quoting of
+        its own, so any argument holding whitespace has to carry its own quotes. The
+        backslash doubling follows the Windows argv rules, which PowerShell also applies
+        when it tokenizes the string on Unix.
+    #>
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [AllowEmptyString()]
+        [string]$Value
+    )
+
+    if ($Value -ne '' -and $Value -notmatch '[\s"]') { return $Value }
+
+    $escaped = $Value -replace '(\\*)"', '$1$1\"'
+    $escaped = $escaped -replace '(\\+)$', '$1$1'
+    '"' + $escaped + '"'
+}
+
 function Invoke-SquadTurn {
     <#
     .SYNOPSIS
@@ -112,12 +136,14 @@ function Invoke-SquadTurn {
     $errorPath = [System.IO.Path]::ChangeExtension($TranscriptPath, '.err.log')
     $started = Get-Date
 
+    # Start-Process joins its argument list with spaces, so the prompt has to arrive
+    # already quoted or the CLI reads each word as a separate argument.
     $arguments = @(
-        '-p', $Prompt
-        '--model', $Model
+        '-p', (ConvertTo-ProcessArgument $Prompt)
+        '--model', (ConvertTo-ProcessArgument $Model)
         '--allow-all-tools'
-        '--deny-tool', 'shell(rm)'
-    )
+        '--deny-tool', (ConvertTo-ProcessArgument 'shell(rm)')
+    ) -join ' '
 
     $process = Start-Process -FilePath 'copilot' -ArgumentList $arguments `
         -WorkingDirectory $Workspace -NoNewWindow -PassThru `


### PR DESCRIPTION
## Summary

The first manual dispatch of *Tier 1 Behavior* failed all three scenarios in under a second each. The harness never reached a squad turn.

## Type of change

- [ ] Feature / new content
- [x] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## The error

```
turn 'init': exit 1 in 0.8s
failed: turn 'init' exited 1: error: Invalid command format.
It looks like your prompt was not quoted, so the extra words were treated as separate arguments.
Wrap the prompt in quotes, for example: copilot -p "your prompt here"
; No squad root matched '.copilot-tracking/squad'. The run did not initialize, or it wrote state somewhere else.
```

`Start-Process` concatenates its argument list with spaces and does no quoting of its own, so the scenario prompt arrived at the CLI as a stream of separate arguments.

The provisioning half was fine — `apm install` completed (300 dependencies in 17.9s) and the workspace was built correctly. Only the invocation was wrong, which is why `-ProvisionOnly` passed on all three scenarios earlier and this did not.

## The fix

A `ConvertTo-ProcessArgument` helper quotes any argument carrying whitespace, doubling backslashes per the Windows argv rules that PowerShell also applies when it tokenizes the string on Unix. Arguments without whitespace stay bare.

Resulting argument string:

```
-p "Act as the Squad Coordinator. Seed state under .copilot-tracking/squad/ and report \"what\" you chose." --model claude-sonnet-5 --allow-all-tools --deny-tool shell(rm)
```

## Change fragment

- [x] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [x] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [x] Its body reads as final release notes, not as a commit message
- [x] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

Not applicable — `tests/` is not part of the consumer package, so this has no consumer-visible effect. Please apply the `skip-changelog` label.

## Shared learning sanitization (if proposing a learning)

Not applicable — this PR does not touch `shared-learnings.md`.

## Notes

Tier 1 self-check still passes 11/0, and the module parse-checks clean.

This unblocks the first real Tier 1 live run. Expect further harness bugs behind it: no scenario has yet completed a single turn, so everything past the invocation is still unproven.
