### PR TITLE
fix(squad): put the consumption block's literal shape where every host can read it

### DIFF
--- a/.changes/unreleased/20260820-the-floor-carries-the-consumption-block.md
+++ b/.changes/unreleased/20260820-the-floor-carries-the-consumption-block.md
@@ -1,0 +1,32 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **The consumption block's field names never reached the host that writes them.** A live single-turn
+  run recorded `modelSource`, `pricedAs`, `internalTurns`, `grossInputTokens`, and `estimatedCostUsd`,
+  invented `baseContext`, `growthPerTurn`, and `dispatchClass`, and omitted all four `*_rate` fields —
+  three of sixteen contractual names survived. The literal shape lived only in the `squad` skill's
+  `references/entry-schemas.md` and in `squad-state.instructions.md`, neither of which loads before
+  squad state is already in play. The sixteen-field JSON block is now reproduced verbatim in
+  `squad-floor.instructions.md`, the one file scoped to `**`, alongside the bare-number rule and the
+  instruction not to translate it into camelCase or add fields
+  (`squad-src/.github/instructions/squad/squad-floor.instructions.md`).
+- **History files were headed with the bare agent name.** Files came back headed `# Squad Researcher`
+  rather than `# History: Squad Researcher` — the exact failure the schema file warns about, which
+  reads to a later turn as a file with no heading at all. The literal heading is now in the floor.
+- **Costs were still being judged rather than derived.** A promotion block recorded
+  `est_cost_usd: 0.047` where its own four token counts times its own four rates give `0.04224`, and
+  `state.json` carried one dispatch's cost as the whole run's. The floor already required the figure
+  to reproduce from the block; it now carries the four-product worked example that was stranded in
+  `references/scribe-procedure.md`, plus the rule that `currentRun`'s totals equal the ledger total.
+- **Promoted sub-squads got a hand-written rate table.** Federation promotion seeded a 957-byte
+  `consumption-rates.md` with four model rows and no tier-fallback table, no dispatch-size estimator,
+  and no calibration block, leaving the Scribe pricing from a table missing what it needs. The floor
+  now states that the file is copied verbatim from the skill template at Init and at every sub-squad
+  seeding or promotion, and that all four sections are load-bearing.
+- **The ledger kept its seed rows and its seed run id.** A turn-2 ledger still read
+  `Run: init-2026-08-20` and carried zero rows for `lead`, `developer`, and `orchestration`, and a
+  promoted ledger labelled its overhead row `scribe`. The floor now fixes `orchestration` as the row
+  label in both tables and states that the rewrite reads every block in `history/` — so an
+  undispatched role has no row rather than a zero row, and the total is the run's, not the turn's.

--- a/squad-src/.github/instructions/squad/squad-floor.instructions.md
+++ b/squad-src/.github/instructions/squad/squad-floor.instructions.md
@@ -1,5 +1,5 @@
 ---
-description: "Unconditional squad floor: state paths and write semantics, the single-writer Scribe rule, dispatch discipline, proof of dispatch, and the Research → Plan → Implement → Review spine — the rules that must hold before any file is in play"
+description: "Unconditional squad floor: state paths and write semantics, the single-writer Scribe rule, dispatch discipline, proof of dispatch, the literal consumption block and its derivation, and the Research → Plan → Implement → Review spine — the rules that must hold before any file is in play"
 applyTo: '**'
 ---
 
@@ -7,7 +7,7 @@ applyTo: '**'
 
 This file carries only the squad rules that must hold before any file is in play. It is scoped to `**` deliberately: every other squad instruction file is gated on `**/.copilot-tracking/squad/**`, so a freshly dispatched agent that has not yet touched squad state runs without them — which is exactly when these rules matter most.
 
-Everything else — profiles, routing, gates, seed templates, the consumption ledger — lives in the `squad` skill and the instruction files named at the bottom, and is read on demand. This is a floor, not a copy.
+Everything else — profiles, routing, gates, seed templates, the ledger procedure — lives in the `squad` skill and the instruction files named at the bottom, and is read on demand. This is a floor, not a copy. The one exception is the consumption block below: it is reproduced literally here because a dispatch that guesses its shape is unreadable to every aggregate above it, and the file that defines it does not load until squad state is already in play.
 
 ## When This Applies
 
@@ -62,11 +62,61 @@ A roster row names one **Primary** agent and optionally some **Alternates**. The
 
 A stage counts as run only when both exist: its domain artifact on disk at the role's `Deliverable Root`, and a `history/<agent>.md` entry written by the Scribe carrying the dispatch's consumption block. No history entry means the stage did not happen and the turn cannot advance past it.
 
-The consumption block is a `#### Consumption` heading followed by a fenced `json` block — level four, no suffix, bare numbers throughout. The only legal variant is `#### Consumption — Orchestration`. Any other heading is unreadable to the ledger rewrite, so the dispatch it records is spent and uncounted. Its `est_cost_usd` is derived from the tokens and rates in that same block and must reproduce from them; a figure that does not is fabricated and corrupts every aggregate above it.
+A history file's own heading is literally `# History: <agent>` — not the bare agent name, not a rewrite of the description. A later turn locates the file by that heading, so a file headed `# Squad Researcher` reads as a file with no heading at all and drops that agent from every ledger rewrite.
 
 Verification is an act, not an assertion: list the directory and read the file. Never report a path this turn did not actually enumerate.
 
 **A stage recorded as complete in `state.json` but absent from `history/` did not run.** The history file is the evidence; a status field is a claim about it. Autonomous and autopilot runs remove the human turn between stages, not this check — when the file is missing, stop at that stage and escalate rather than advancing on the strength of the claim.
+
+## The Consumption Block Is Literal
+
+Every dispatch entry carries a `#### Consumption` heading followed by a fenced `json` block — level four, no suffix. The only legal variant is `#### Consumption — Orchestration`, which the coordinator's and Scribe's own turns are recorded under in `history/Squad Scribe.md`. Any other heading is unreadable to the ledger rewrite, so the dispatch it records is spent and uncounted.
+
+The field names, their `snake_case` spelling, their order, and the set itself are contractual. Copy this shape; do not translate it into camelCase, drop the four rate fields, or add fields of your own:
+
+```json
+{
+  "model": "<resolved model or unknown>",
+  "model_source": "<dispatch-reported|agent-pinned|operator-declared|session-inherited|cli-pinned|unresolved>",
+  "priced_as": "<rate row used, when it differs from model>",
+  "model_tier": "<fast|default|extended>",
+  "internal_turns": 0,
+  "input_tokens": 0,
+  "cached_tokens": 0,
+  "cache_write_tokens": 0,
+  "output_tokens": 0,
+  "input_rate": 0,
+  "cached_rate": 0,
+  "cache_write_rate": 0,
+  "output_rate": 0,
+  "est_cost_usd": 0,
+  "est_credits": 0,
+  "basis": "<estimated|tier-default>"
+}
+```
+
+Every numeric field is a bare number: `172800`, never `~172,800`, `"172800"`, or `172800 tokens`. `priced_as` is the rate row's own label from `consumption-rates.md`, spelled as that table spells it.
+
+**Derive `est_cost_usd`; never estimate it.** By the time this field is written its four token counts and four rates are already decided, so it has exactly one correct value and any other value is fabricated. Compute the four products separately, sum them, divide by `1e6`, then multiply by the `calibration_factor` from `consumption-rates.md`. Worked example at a factor of `1.00`; the block itself records bare numbers, the separators below are only for reading:
+
+```text
+ 57600 ×  3.00  =  172800
+230400 ×  0.30  =   69120
+ 95200 ×  3.75  =  357000
+ 15000 × 15.00  =  225000
+                  -------
+                   823920  / 1e6  =  est_cost_usd 0.82392  ->  est_credits 82.39
+```
+
+`est_credits` is `est_cost_usd / 0.01`. Read the block back before moving on and confirm the recorded cost reproduces from the recorded tokens and rates: a block whose cost does not follow from its own numbers corrupts the run total, the `state.json` figures, and any autonomous-mode cost ceiling computed from them.
+
+## Two Files the Ledger Reads Back
+
+`consumption-rates.md` is **copied verbatim** from the template in the `squad` skill's `references/consumption.md`, at Init and at every sub-squad seeding or federation promotion. It carries the per-model rate table, the tier-fallback table, the dispatch-size estimator, and the calibration block, and all four are load-bearing. A shortened, summarized, or hand-rewritten rate file leaves the Scribe pricing from a table that no longer contains what it needs.
+
+In `consumption.md`, the row covering the coordinator's and Scribe's own turns is labelled **`orchestration`** in both tables — never `scribe`, `coordinator`, or a split pair. It is derived from the `#### Consumption — Orchestration` blocks the same way every other row is derived from its dispatch blocks.
+
+The ledger is rewritten from **every** block recorded for the run, not from this turn's. So a role that has never been dispatched carries no row at all rather than a row of zeros; the run total is the sum of every block in `history/`; the `Run:` id in the heading is the current run, not the one Init seeded; and `state.json`'s `currentRun` cost figures equal that same total. A ledger rewritten from one turn silently drops every earlier role while still looking complete.
 
 ## The Methodology Spine Is Not Optional
 


### PR DESCRIPTION
Follow-up to #79, driven by Tier 1 run [32374220726](https://github.com/Peter-N91/hve-squad/actions/runs/32374220726) on `main @ c5fdb6b`: `single-init` passed, `single-turn` failed 13 of 83, `federation-promotion` failed 4-6 per sub-squad tree.

The failures were almost entirely disjoint between the two jobs, and that split is the finding. Every rule that broke has its literal form in a file that does not reach the Copilot CLI host; every rule that held is already in `squad-floor.instructions.md`, the only file scoped to `**`.

| Defect | Literal form lived in | Reached host |
|---|---|---|
| 16 field names, snake_case, in order | `references/entry-schemas.md`, `squad-state.instructions.md` | no |
| `# History: <agent>` | `references/entry-schemas.md` | no |
| Rate file copied verbatim | `references/consumption.md` template | no |
| Four-product derivation example | `references/scribe-procedure.md` | no |
| Overhead row named `orchestration` | `references/scribe-procedure.md` | no |
| `#### Consumption` heading level and suffix rule | **the floor** | **yes - correct in every block, both jobs** |
| `state.json` key set | **the floor + #79** | **yes - clean in both jobs** |
| History file named by verbatim agent name | **the floor** | **yes - correct everywhere** |

`entry-schemas.md` predicts the exact failure verbatim - "a file headed `# Squad Researcher` reads as a file with no header at all". The documentation is not ambiguous, it is unreachable.

## What changed

One file. Four literal additions to `squad-floor.instructions.md`:

1. The sixteen-field JSON block, reproduced verbatim, replacing the prose description.
2. `# History: <agent>` as a literal heading rule.
3. The four-product worked example previously stranded in `scribe-procedure.md`, plus `currentRun` totals equalling the ledger total.
4. `consumption-rates.md` is copied verbatim at Init and at every sub-squad seeding or promotion; the overhead row is labelled `orchestration`; the rewrite reads every block in `history/`, so an undispatched role has no row rather than a zero row.

## Tradeoff

The floor grows from ~9.4 KB to 12.6 KB and loads on every turn of every host. Three live runs now show that prose in the floor holds and literals outside it do not, so this is the only channel with a demonstrated delivery rate. The preamble's "this is a floor, not a copy" claim is amended rather than quietly broken.

## Validation

| Check | Result |
|---|---|
| Tier 0 conformance | 575 passed, 0 failed, 1 skipped |
| Tier 1 mutation self-check | 19 passed, 0 failed |
| markdownlint (MD013/MD041/MD060 excluded) | 16 issues, unchanged from baseline, none in the edited file |

No test changes: the existing contract already catches all five defects. Tier 1 live has not been re-run against this branch - that is the next step after merge.