### PR TITLE
fix(squad): stop the Scribe writing the viewer's line numbers into squad state

### DIFF
--- a/.changes/unreleased/20260820-line-numbers-are-not-file-content.md
+++ b/.changes/unreleased/20260820-line-numbers-are-not-file-content.md
@@ -1,0 +1,39 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **A history file came back with the read tool's line-number gutter baked into it.** Every line of
+  `history/Squad Scribe.md` was written as `1. ---`, `2. description: ...`, `5. # History: Squad
+  Scribe` — the content was correct, the file was unparseable. The template had been copied out of a
+  numbered read view and written back with the numbering intact, which reads as correct to a human
+  and as nothing at all to every later turn. The floor now states that line numbers belong to the
+  viewer and are stripped before writing, and Tier 1 fails any state file whose opening lines carry a
+  gutter (`squad-src/.github/instructions/squad/squad-floor.instructions.md`,
+  `tests/tier1/SquadState.psm1`, `tests/tier1/StateContract.Tests.ps1`,
+  `tests/tier1/Assertions.Tests.ps1`).
+- **Estimator working values were leaking into the consumption block.** Blocks carried
+  `dispatch_class`, `base_context`, `growth_per_turn`, and `output_per_turn` alongside the sixteen
+  contractual fields. Those are inputs the Scribe reasons with, not fields it records. The floor now
+  says the set is closed at sixteen and names the four that leak.
+- **The rate fields were being renamed and zeroed.** One run wrote `input_rate_usd_per_1m` and its
+  three siblings, which read as four missing fields; another wrote `cache_write_rate: 0` against a
+  rate row that says `3.75`. The floor now fixes the four names, states that the unit lives in the
+  contract rather than the field name, and requires all four rates to be copied from the row as the
+  row states them even when the matching token count is zero.
+- **`priced_as` was omitted or written as a slug.** Blocks priced `claude-sonnet-5` against a table
+  whose row is `Claude Sonnet 5`, or dropped the field entirely and left the ledger pricing from
+  `model`. The floor now requires the field on every block, copied character-for-character from the
+  rate table's `Model (as routed)` cell, equal to `model` when no fallback happened.
+- **A factor-of-ten slip survived every other check.** A block summing to `113520` recorded
+  `est_cost_usd: 1.17` rather than `0.11352`; the block was otherwise perfectly formed. The floor now
+  calls out the single division by `1e6` and asks for a digit comparison before the block is
+  appended.
+- **The orchestration row kept appearing without a block behind it.** One ledger carried a zero
+  `orchestration` row, another a `0.0779` row, and neither had a single `#### Consumption —
+  Orchestration` block in `history/`. The floor now says the Scribe writes that block on every turn
+  it writes state, Init included, and that no block means no row.
+- **The literal history-file preamble is now in the floor.** Files were still headed `# Squad
+  Researcher` under invented descriptions like `"Dispatch history for Squad Researcher role"`,
+  because the heading rule was stated while the template it describes lived two files away. Both now
+  sit together in the one file that loads on every host.

--- a/squad-src/.github/instructions/squad/squad-floor.instructions.md
+++ b/squad-src/.github/instructions/squad/squad-floor.instructions.md
@@ -40,6 +40,8 @@ Only the **Squad Scribe** writes squad state. Every other agent, including both 
 
 Append-only files are appended to and never edited or removed. A coordinator that edits `decisions.md`, `history/`, or `state.json` directly has broken the contract, even when the edit is correct.
 
+**Line numbers are never file content.** A read tool renders a `1.`, `2.`, `12:` gutter down the left margin so you can cite a line; it belongs to the viewer, not to the file. Copying a template out of a numbered view and writing it back with the gutter intact produces a file nothing downstream can parse — including this contract's own checks. Strip the numbering before writing, every time.
+
 ## Dispatch Discipline
 
 A coordinator classifies, dispatches, collects, synthesizes, and escalates. It never performs a role's work itself, in any mode — interactive, autonomous, or autopilot. This is the rule that makes the squad a methodology rather than one model improvising.
@@ -62,7 +64,17 @@ A roster row names one **Primary** agent and optionally some **Alternates**. The
 
 A stage counts as run only when both exist: its domain artifact on disk at the role's `Deliverable Root`, and a `history/<agent>.md` entry written by the Scribe carrying the dispatch's consumption block. No history entry means the stage did not happen and the turn cannot advance past it.
 
-A history file's own heading is literally `# History: <agent>` — not the bare agent name, not a rewrite of the description. A later turn locates the file by that heading, so a file headed `# Squad Researcher` reads as a file with no heading at all and drops that agent from every ledger rewrite.
+A history file is created by the dispatch it records, with this preamble and nothing else above the first entry:
+
+```markdown
+---
+description: "Append-only dispatch history for a single squad agent"
+---
+
+# History: <agent>
+```
+
+The heading is literally `# History: <agent>` — not the bare agent name, not a rewrite of the description. A later turn locates the file by that heading, so a file headed `# Squad Researcher` reads as a file with no heading at all and drops that agent from every ledger rewrite. The file name is the agent's `name:` verbatim, so `history/Squad Scribe.md`, never `history/scribe.md`.
 
 Verification is an act, not an assertion: list the directory and read the file. Never report a path this turn did not actually enumerate.
 
@@ -95,7 +107,15 @@ The field names, their `snake_case` spelling, their order, and the set itself ar
 }
 ```
 
-Every numeric field is a bare number: `172800`, never `~172,800`, `"172800"`, or `172800 tokens`. `priced_as` is the rate row's own label from `consumption-rates.md`, spelled as that table spells it.
+Every numeric field is a bare number: `172800`, never `~172,800`, `"172800"`, or `172800 tokens`.
+
+Three rules keep the block parseable, and each one has been broken by a real run:
+
+* **The set is closed at sixteen.** Estimator working values — `dispatch_class`, `base_context`, `growth_per_turn`, `output_per_turn`, `gross_input_tokens` — are inputs you reason with, not fields you record. They belong in the entry prose above the block, never inside it.
+* **The rate fields are named `input_rate`, `cached_rate`, `cache_write_rate`, `output_rate`.** The unit is USD per 1M tokens and it lives in the contract, not in the field name; `input_rate_usd_per_1m` is a different field and reads as a missing one.
+* **`priced_as` is always present, and it is copied character-for-character from the rate table's `Model (as routed)` cell.** `Claude Sonnet 5`, never `claude-sonnet-5`. When no fallback happened it equals `model`; write it anyway, because the ledger prices from `priced_as` and a slug matches no row.
+
+Copy all four rates from that row as the row states them, even when the matching token count is zero. A rate is a property of the model; `cache_write_rate: 0` against a row that says `3.75` says the model is free to cache, which is false and makes the block irreproducible.
 
 **Derive `est_cost_usd`; never estimate it.** By the time this field is written its four token counts and four rates are already decided, so it has exactly one correct value and any other value is fabricated. Compute the four products separately, sum them, divide by `1e6`, then multiply by the `calibration_factor` from `consumption-rates.md`. Worked example at a factor of `1.00`; the block itself records bare numbers, the separators below are only for reading:
 
@@ -110,11 +130,13 @@ Every numeric field is a bare number: `172800`, never `~172,800`, `"172800"`, or
 
 `est_credits` is `est_cost_usd / 0.01`. Read the block back before moving on and confirm the recorded cost reproduces from the recorded tokens and rates: a block whose cost does not follow from its own numbers corrupts the run total, the `state.json` figures, and any autonomous-mode cost ceiling computed from them.
 
+Divide by `1e6` exactly once. The commonest corruption in this file is a factor-of-ten slip — a block summing to `113520` recorded as `1.17` rather than `0.11352` — which survives every other check because the block is otherwise well formed. Compare the digits of your sum against the digits of what you wrote before appending.
+
 ## Two Files the Ledger Reads Back
 
 `consumption-rates.md` is **copied verbatim** from the template in the `squad` skill's `references/consumption.md`, at Init and at every sub-squad seeding or federation promotion. It carries the per-model rate table, the tier-fallback table, the dispatch-size estimator, and the calibration block, and all four are load-bearing. A shortened, summarized, or hand-rewritten rate file leaves the Scribe pricing from a table that no longer contains what it needs.
 
-In `consumption.md`, the row covering the coordinator's and Scribe's own turns is labelled **`orchestration`** in both tables — never `scribe`, `coordinator`, or a split pair. It is derived from the `#### Consumption — Orchestration` blocks the same way every other row is derived from its dispatch blocks.
+In `consumption.md`, the row covering the coordinator's and Scribe's own turns is labelled **`orchestration`** in both tables — never `scribe`, `coordinator`, or a split pair. It is derived from the `#### Consumption — Orchestration` blocks the same way every other row is derived from its dispatch blocks, so the Scribe writes one such block into `history/Squad Scribe.md` on every turn it writes state, including Init. No block means no row — an `orchestration` row carrying a figure no block accounts for is invented, and a zero row hides the cost of running the squad.
 
 The ledger is rewritten from **every** block recorded for the run, not from this turn's. So a role that has never been dispatched carries no row at all rather than a row of zeros; the run total is the sum of every block in `history/`; the `Run:` id in the heading is the current run, not the one Init seeded; and `state.json`'s `currentRun` cost figures equal that same total. A ledger rewritten from one turn silently drops every earlier role while still looking complete.
 

--- a/tests/tier1/Assertions.Tests.ps1
+++ b/tests/tier1/Assertions.Tests.ps1
@@ -171,6 +171,14 @@ Describe 'The contract catches a broken tree' {
         (Test-Contract $root).Passed | Should -BeFalse -Because 'currentRun is a running total, not a scratchpad'
     }
 
+    It 'catches a file written with a read tool line-number gutter' {
+        $root = New-Fixture 'numbered-lines'
+        $path = Join-Path $root 'history/Squad Researcher.md'
+        $numbered = @(Get-Content -LiteralPath $path | ForEach-Object -Begin { $i = 0 } -Process { $i++; "$i. $_" })
+        Set-Content -LiteralPath $path -Value $numbered -Encoding utf8NoBOM
+        (Test-Contract $root).Passed | Should -BeFalse -Because 'a gutter that reads as content leaves the file parseable to nobody'
+    }
+
     It 'catches an undocumented autonomy mode' {
         $root = New-Fixture 'bad-mode'
         Edit-Fixture -Path (Join-Path $root 'state.json') `

--- a/tests/tier1/SquadState.psm1
+++ b/tests/tier1/SquadState.psm1
@@ -281,6 +281,17 @@ function Get-SquadStateModel {
 
     $blocks = @(foreach ($file in $historyFiles) { Get-ConsumptionBlock -Path $file.FullName })
 
+    # A template copied out of a line-numbered read view keeps the viewer's gutter, which
+    # leaves the file well formed to the eye and unparseable to everything downstream.
+    # Scoped to state files: a deliverable may legitimately open with a numbered list.
+    $numberedFiles = @(
+        foreach ($file in (@(Get-ChildItem -LiteralPath $SquadRoot -Filter '*.md' -File -ErrorAction SilentlyContinue) + $historyFiles)) {
+            $lines = @(Get-Content -LiteralPath $file.FullName -TotalCount 12 -ErrorAction SilentlyContinue)
+            $gutter = @($lines | Where-Object { $_ -match '^\s*\d+[.:]\s' })
+            if ($gutter.Count -ge 3) { $file.Name }
+        }
+    )
+
     $ledgerContent = Read-Text 'consumption.md'
     $ratesContent = Read-Text 'consumption-rates.md'
     $teamContent = Read-Text 'team.md'
@@ -324,6 +335,7 @@ function Get-SquadStateModel {
         HasHistoryDir    = Test-Path -LiteralPath $historyDirectory
         HistoryFiles     = $historyFiles
         HistoryNames     = @($historyFiles | ForEach-Object { $_.BaseName })
+        NumberedFiles    = @($numberedFiles)
         State            = $stateJson
         Team             = $teamContent
         RosterAgents     = @($rosterAgents)

--- a/tests/tier1/StateContract.Tests.ps1
+++ b/tests/tier1/StateContract.Tests.ps1
@@ -38,6 +38,12 @@ Describe 'SQ-01 Init seeds the eager state files' {
     It 'creates the history directory' {
         $script:Model.HasHistoryDir | Should -BeTrue
     }
+
+    # A file copied out of a line-numbered read view keeps the viewer's gutter, which reads
+    # as correct content to a human and parses as nothing at all to every later turn.
+    It 'writes no file carrying a read tool line-number gutter' {
+        $script:Model.NumberedFiles -join ', ' | Should -BeNullOrEmpty -Because 'line numbers belong to the viewer, not the file'
+    }
 }
 
 Describe 'SQ-03 state.json carries the documented shape' {


### PR DESCRIPTION
Follow-up to #80, driven by Tier 1 run [32382138170](https://github.com/Peter-N91/hve-squad/actions/runs/32382138170) on `main @ d31d62e`.

## #80 worked, and the failures moved

| Job / tree | Before #80 | After #80 |
|---|---|---|
| `single-turn` attempt-2 | 13 failed | **5 failed** |
| `federation-promotion` default attempt-2 | 6 failed | **4 failed** |
| `federation-promotion` persistence attempt-2 | 5 failed | **2 failed** |

The consumption block is now well formed in most trees. What remains is a different, sharper set - including one defect I have not seen before.

## The new one

`history/Squad Scribe.md` came back with the read tool's line-number gutter written into the file:

```text
1. ---
2. description: "Append-only dispatch history for a single squad agent"
3. ---
4.
5. # History: Squad Scribe
```

The content is correct. The heading is correct. The field order below it is correct. The file is unparseable, because every line carries `N.`. The template was copied out of a numbered read view and written back with the gutter intact - a side effect of #80 telling it to copy the template rather than compose one. Only that one file was affected; the other eight in the same tree are clean.

## The rest

| # | Defect | Evidence |
|---|---|---|
| 1 | Estimator working values leaking into the block | `dispatch_class`, `base_context`, `growth_per_turn`, `output_per_turn` recorded as fields |
| 2 | Rate fields renamed with the unit | `input_rate_usd_per_1m` and its three siblings - reads as four missing fields |
| 3 | Rate fields zeroed against a non-zero row | `cache_write_rate: 0` where the table says `3.75` |
| 4 | `priced_as` omitted, or written as a slug | `claude-sonnet-5` against a row reading `Claude Sonnet 5` |
| 5 | Factor-of-ten slip | block sums to `113520`; recorded `1.17` not `0.11352` |
| 6 | Orchestration row with no block behind it | ledger row `0.0779`, zero `#### Consumption - Orchestration` blocks in `history/` |
| 7 | `# History:` heading still drifting on attempt-1 of both jobs | headed `# Squad Researcher` under an invented description |
| 8 | History file named by role id | `history/scribe.md` |

## What changed

**Floor** - the line-number rule; the literal history-file preamble beside the heading rule it describes; the field set stated as closed at sixteen with the four leakers named; the four rate field names fixed and the unit placed in the contract rather than the name; all four rates copied from the row even when the token count is zero; `priced_as` required on every block, character-for-character from the `Model (as routed)` cell; the single division by `1e6` called out with the observed slip as the example; the Scribe required to write an orchestration block every turn it writes state, Init included.

**Harness** - a new contract case, `writes no file carrying a read tool line-number gutter`, scoped to state files so a deliverable may still open with a numbered list, plus a mutation control that renumbers a fixture file and proves the case fires. Verified against the real failing tree: flags `Squad Scribe.md` and nothing else across all six captured trees.

## Validation

| Check | Result |
|---|---|
| Tier 0 conformance | 575 passed, 0 failed, 1 skipped |
| Tier 1 mutation self-check | **20 passed**, 0 failed (was 19) |
| markdownlint (MD013/MD041/MD060 excluded) | 16 issues, unchanged from baseline |
| New check against 6 captured live trees | 1 true positive, 0 false positives |