### PR TITLE
fix(build): publish the validated hve-core pin as a marketplace entry

### DIFF
--- a/.changes/unreleased/20260824-marketplace-ships-the-validated-hve-core-pin.md
+++ b/.changes/unreleased/20260824-marketplace-ships-the-validated-hve-core-pin.md
@@ -1,0 +1,20 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **The published plugin marketplace could pair a release with an hve-core commit it was never
+  validated against.** The generated `marketplace.json` carried a single `hve-squad` entry and
+  `autoUpdate: true`, leaving hve-core to be installed separately from its own source — so a
+  consumer resolved whatever was current upstream rather than the commit the installed squad
+  version's routing tables and role charters were built against.
+
+  `Build-SquadPlugin.ps1` now emits a second `hve-squad-hve-core` entry whose commit SHA is read
+  from the built ref's own `apm.yml`, so each release publishes the exact hve-core pin its
+  cast-delta guard validated — `v0.16.1` resolves `b1cae50`, `v0.16.2-pre` resolves `3050cf5`,
+  with no manifest hand-editing. `autoUpdate` is dropped deliberately: the two entries are a
+  matched pair, and an unattended update of one without the other reintroduces the same skew.
+
+  `publish-plugin.yml` gains an optional `mcp-version` input so a publish can bump the
+  `@hve-squad/mcp` pin in the same run; omitted, the existing `.mcp.json` pin is reused rather
+  than silently advanced.

--- a/.github/workflows/publish-plugin.yml
+++ b/.github/workflows/publish-plugin.yml
@@ -20,6 +20,10 @@ on:
         description: 'hve-squad tag to build from. Leave blank to use the highest released version tag (vX.Y.Z, pre-releases excluded).'
         required: false
         type: string
+      mcp-version:
+        description: 'Optional: exact @hve-squad/mcp version to pin (e.g. 0.7.1). Leave blank to keep the pin already in hve-squad-plugin''s .mcp.json.'
+        required: false
+        type: string
 
 concurrency:
   group: ${{ github.workflow }}
@@ -88,11 +92,23 @@ jobs:
           path: hve-squad-plugin
           fetch-depth: 0
 
+      # The generator re-derives the marketplace's hve-core pin from this tag's
+      # own apm.yml, so a release that moved the pin publishes the matching
+      # hve-squad-hve-core entry without anyone editing the manifest by hand.
+      # -McpVersion is the one axis that stays deliberate: omitted, the existing
+      # .mcp.json pin is reused rather than silently advanced.
       - name: Build the plugin tree
         shell: pwsh
         env:
           TAG: ${{ steps.tag.outputs.ref }}
-        run: ./scripts/Build-SquadPlugin.ps1 -Ref $env:TAG -OutputRoot "${{ github.workspace }}/hve-squad-plugin"
+          MCP_VERSION: ${{ inputs.mcp-version }}
+        run: |
+          $buildArgs = @{
+              Ref        = $env:TAG
+              OutputRoot = "${{ github.workspace }}/hve-squad-plugin"
+          }
+          if ($env:MCP_VERSION) { $buildArgs.McpVersion = $env:MCP_VERSION }
+          ./scripts/Build-SquadPlugin.ps1 @buildArgs
 
       # ── Commit, tag, and push into hve-squad-plugin ───────────────────────
       #    Re-running against a tag that produced no change is a no-op commit,

--- a/scripts/Build-SquadPlugin.ps1
+++ b/scripts/Build-SquadPlugin.ps1
@@ -535,6 +535,21 @@ if ($MyInvocation.InvocationName -ne '.') {
             -Content (($pluginManifest | ConvertTo-Json -Depth 10) + "`n") -DryRun:$DryRun
 
         # ── marketplace.json (P02-T07 scaffold, P04-T02-aware) ──
+        #    autoUpdate is deliberately absent: a consumer must receive the
+        #    hve-squad and hve-core entries as a matched pair (see below), and
+        #    an unattended update of one without the other reintroduces the
+        #    version skew the pinned hve-core entry exists to prevent.
+
+        # The hve-core entry ships the exact commit this hve-squad ref's apm.yml
+        # was validated against, so a consumer never resolves hve-core content
+        # newer than the routing and charters that reference it.
+        $apmYaml = Get-SourceFileContent -Source $source -RepoRoot $RepoRoot -RelativePath 'apm.yml'
+        $hveCoreSha = ([regex]::Match($apmYaml, 'microsoft/hve-core/[^\s#]+#([0-9a-f]{40})')).Groups[1].Value
+        if (-not $hveCoreSha) {
+            throw "Could not resolve the microsoft/hve-core commit pin from apm.yml at '$($source.Ref)'. The marketplace's hve-core entry must ship the exact validated commit, so refusing to emit an unpinned entry."
+        }
+        Write-Host "hve-core: pinning marketplace entry to $($hveCoreSha.Substring(0,7))" -ForegroundColor Cyan
+
         $marketplaceManifest = [ordered]@{
             name       = 'hve-squad-plugin'
             owner      = [ordered]@{ name = 'Peter-N91' }
@@ -542,7 +557,6 @@ if ($MyInvocation.InvocationName -ne '.') {
                 description = 'Marketplace for the hve-squad GitHub Copilot plugin, generated and release-gated from Peter-N91/hve-squad.'
                 version     = $source.PluginVersion
             }
-            autoUpdate = $true
             plugins    = @(
                 [ordered]@{
                     name        = 'hve-squad'
@@ -554,6 +568,18 @@ if ($MyInvocation.InvocationName -ne '.') {
                         ref    = 'main'
                     }
                     repository  = 'https://github.com/Peter-N91/hve-squad-plugin'
+                    license     = 'MIT'
+                }
+                [ordered]@{
+                    name        = 'hve-squad-hve-core'
+                    description = "microsoft/hve-core pinned to the exact commit validated against hve-squad $($source.PluginVersion)'s apm.yml (Sync and Adapt / cast-delta guard). Named distinctly from the official hve-core plugin so both can be registered side by side."
+                    version     = $source.PluginVersion
+                    source      = [ordered]@{
+                        source = 'github'
+                        repo   = 'microsoft/hve-core'
+                        sha    = $hveCoreSha
+                    }
+                    repository  = 'https://github.com/microsoft/hve-core'
                     license     = 'MIT'
                 }
             )


### PR DESCRIPTION
## Summary

Makes the published plugin marketplace ship the hve-core commit each hve-squad release was actually validated against, instead of leaving hve-core to be installed from its own source at whatever is current there.

## Problem

`marketplace.json` carried a single `hve-squad` entry plus `autoUpdate: true`. Most squad roles resolve to an hve-core agent, so consumers installed hve-core separately — resolving upstream's current state, which can be ahead of the routing tables and role charters the installed squad version references.

This was not theoretical: the manually-added entry pinned `3050cf5`, which arrived in `5ac1a5b` (part of `v0.16.2-pre`) and is **not** contained in `v0.16.1` (`git merge-base --is-ancestor` → false). The published 0.16.1 plugin tree was validated against `b1cae50`.

## Changes

- **`scripts/Build-SquadPlugin.ps1`** — emits a second `hve-squad-hve-core` marketplace entry whose SHA is parsed from the built ref's own `apm.yml`, and throws rather than emitting an unpinned entry if that pin cannot be resolved. Drops `autoUpdate`: the entries are a matched pair, and updating one without the other reintroduces the same skew.
- **`.github/workflows/publish-plugin.yml`** — adds an optional `mcp-version` input threaded to `-McpVersion`, so a publish can bump the MCP pin in the same run. Omitted, the existing `.mcp.json` pin is reused rather than silently advanced.

## Verification

Per-ref derivation confirmed by building both tags:

| Ref | Resolved hve-core pin |
|---|---|
| `v0.16.1` | `b1cae50` |
| `v0.16.2-pre` | `3050cf5` |

Workflow YAML parses and exposes both inputs. The corresponding manifest correction and paired install/update documentation are pushed to `hve-squad-plugin` (`c0ca4f4`).

🔒 - Generated by Copilot
