### PR TITLE
feat(security): publish supply-chain posture badges and security policy

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    commit-message:
+      prefix: "chore(deps)"
+    labels:
+      - "dependencies"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,56 @@
+# OpenSSF Scorecard supply-chain posture analysis. Results are uploaded to the
+# Security tab and published to the public OpenSSF API, which is what backs the
+# Scorecard badge in README.md.
+name: OpenSSF Scorecard
+
+on:
+  branch_protection_rule:
+  push:
+    branches: ["main"]
+  schedule:
+    - cron: '18 5 * * 2'
+  workflow_dispatch:
+
+permissions: {}
+
+concurrency:
+  group: scorecard-${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload the SARIF result to the Security tab
+      id-token: write # publish results to the OpenSSF API (badge data)
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@2d1146689b8cda280b9bc96326124645441f03bc # v2.4.4
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload SARIF as artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: scorecard-sarif
+          path: results.sarif
+          retention-days: 30
+
+      - name: Upload SARIF file
+        if: (!cancelled())
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif
+          category: scorecard

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ apm_modules/
 !.github/workflows/
 !.github/workflows/**
 !.github/pull_request_template.md
+!.github/dependabot.yml
 .agents/
 
 # Agent tracking artifacts.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   <a href="https://github.com/Peter-N91/hve-squad/actions/workflows/checkov.yml"><img src="https://github.com/Peter-N91/hve-squad/actions/workflows/checkov.yml/badge.svg" alt="Checkov" /></a>
   <br />
   <a href="https://scorecard.dev/viewer/?uri=github.com/Peter-N91/hve-squad"><img src="https://api.scorecard.dev/projects/github.com/Peter-N91/hve-squad/badge" alt="OpenSSF Scorecard" /></a>
-  <a href="https://www.bestpractices.dev/projects/14231"><img src="https://www.bestpractices.dev/projects/PROJECT_ID/badge" alt="OpenSSF Best Practices" /></a>
+  <a href="https://www.bestpractices.dev/projects/14231"><img src="https://www.bestpractices.dev/projects/14231/badge" alt="OpenSSF Best Practices" /></a>
   <a href="https://github.com/Peter-N91/hve-squad/releases/latest"><img src="https://img.shields.io/github/v/release/Peter-N91/hve-squad?sort=semver" alt="Latest release" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/Peter-N91/hve-squad" alt="License" /></a>
   <a href="https://peter-n91.github.io/hve-squad/"><img src="https://img.shields.io/badge/docs-peter--n91.github.io%2Fhve--squad-blue" alt="Documentation" /></a>

--- a/README.md
+++ b/README.md
@@ -18,9 +18,7 @@
   <a href="https://github.com/Peter-N91/hve-squad/actions/workflows/checkov.yml"><img src="https://github.com/Peter-N91/hve-squad/actions/workflows/checkov.yml/badge.svg" alt="Checkov" /></a>
   <br />
   <a href="https://scorecard.dev/viewer/?uri=github.com/Peter-N91/hve-squad"><img src="https://api.scorecard.dev/projects/github.com/Peter-N91/hve-squad/badge" alt="OpenSSF Scorecard" /></a>
-  <!-- Enroll at https://www.bestpractices.dev/en/projects/new, then replace PROJECT_ID below and uncomment.
-  <a href="https://www.bestpractices.dev/projects/PROJECT_ID"><img src="https://www.bestpractices.dev/projects/PROJECT_ID/badge" alt="OpenSSF Best Practices" /></a>
-  -->
+  <a href="https://www.bestpractices.dev/projects/14231"><img src="https://www.bestpractices.dev/projects/PROJECT_ID/badge" alt="OpenSSF Best Practices" /></a>
   <a href="https://github.com/Peter-N91/hve-squad/releases/latest"><img src="https://img.shields.io/github/v/release/Peter-N91/hve-squad?sort=semver" alt="Latest release" /></a>
   <a href="./LICENSE"><img src="https://img.shields.io/github/license/Peter-N91/hve-squad" alt="License" /></a>
   <a href="https://peter-n91.github.io/hve-squad/"><img src="https://img.shields.io/badge/docs-peter--n91.github.io%2Fhve--squad-blue" alt="Documentation" /></a>

--- a/README.md
+++ b/README.md
@@ -10,6 +10,23 @@
   your request to a cast of agents in parallel.
 </p>
 
+<!-- markdownlint-disable MD013 MD033 -->
+<p align="center">
+  <a href="https://github.com/Peter-N91/hve-squad/actions/workflows/pr-validation.yml"><img src="https://github.com/Peter-N91/hve-squad/actions/workflows/pr-validation.yml/badge.svg" alt="PR Validation" /></a>
+  <a href="https://github.com/Peter-N91/hve-squad/actions/workflows/codeql.yml"><img src="https://github.com/Peter-N91/hve-squad/actions/workflows/codeql.yml/badge.svg" alt="CodeQL" /></a>
+  <a href="https://github.com/Peter-N91/hve-squad/actions/workflows/zizmor.yml"><img src="https://github.com/Peter-N91/hve-squad/actions/workflows/zizmor.yml/badge.svg" alt="Zizmor" /></a>
+  <a href="https://github.com/Peter-N91/hve-squad/actions/workflows/checkov.yml"><img src="https://github.com/Peter-N91/hve-squad/actions/workflows/checkov.yml/badge.svg" alt="Checkov" /></a>
+  <br />
+  <a href="https://scorecard.dev/viewer/?uri=github.com/Peter-N91/hve-squad"><img src="https://api.scorecard.dev/projects/github.com/Peter-N91/hve-squad/badge" alt="OpenSSF Scorecard" /></a>
+  <!-- Enroll at https://www.bestpractices.dev/en/projects/new, then replace PROJECT_ID below and uncomment.
+  <a href="https://www.bestpractices.dev/projects/PROJECT_ID"><img src="https://www.bestpractices.dev/projects/PROJECT_ID/badge" alt="OpenSSF Best Practices" /></a>
+  -->
+  <a href="https://github.com/Peter-N91/hve-squad/releases/latest"><img src="https://img.shields.io/github/v/release/Peter-N91/hve-squad?sort=semver" alt="Latest release" /></a>
+  <a href="./LICENSE"><img src="https://img.shields.io/github/license/Peter-N91/hve-squad" alt="License" /></a>
+  <a href="https://peter-n91.github.io/hve-squad/"><img src="https://img.shields.io/badge/docs-peter--n91.github.io%2Fhve--squad-blue" alt="Documentation" /></a>
+</p>
+<!-- markdownlint-enable MD013 MD033 -->
+
 ## Documentation
 
 Full documentation lives on the project site:
@@ -71,6 +88,18 @@ apm install "Peter-N91/hve-squad#vX.Y.z-pre" --target copilot
 
 That tag moves on every merge, so re-run the command to pick up the newest build. Use it
 to try a fix before it ships; pin a released version for anything you depend on.
+
+## Security
+
+Every change to `main` runs CodeQL, Checkov, Zizmor, OpenSSF Scorecard, and a
+three-tier conformance suite over the shipped agent assets. Third-party GitHub
+Actions are pinned to full commit SHAs and workflows run with least-privilege
+tokens.
+
+To report a vulnerability, use
+[private security advisories](https://github.com/Peter-N91/hve-squad/security/advisories/new)
+rather than a public issue. See [SECURITY.md](SECURITY.md) for the threat model,
+scope, and response times.
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,80 @@
+# Security Policy
+
+## Supported versions
+
+hve-squad is a solo-maintained, pre-1.0 project. Only the latest published
+release receives security fixes. Older tags are kept for reproducibility and are
+not patched. See [CHANGELOG.md](CHANGELOG.md) for what shipped in each version.
+
+| Version              | Supported |
+|----------------------|-----------|
+| Latest release       | Yes       |
+| Rolling `-pre` tag   | Best effort |
+| Any earlier tag      | No        |
+
+## Reporting a vulnerability
+
+**Do not open a public issue for a security vulnerability.**
+
+Report it privately through GitHub Security Advisories:
+[Report a vulnerability](https://github.com/Peter-N91/hve-squad/security/advisories/new).
+
+Please include:
+
+- The affected version or commit.
+- The component involved (agent, prompt, instruction, skill, workflow, or script).
+- Reproduction steps and the impact you observed.
+- Any suggested mitigation.
+
+You can expect an acknowledgement within 5 business days and a status update
+within 10 business days. Fixes ship in the next release; the advisory is
+published once a fix is available. Coordinated disclosure is appreciated.
+
+Vulnerabilities in a dependency (most notably
+[microsoft/hve-core](https://github.com/microsoft/hve-core)) should be reported
+to that project. If the issue is in how hve-squad composes or deploys a
+dependency, report it here.
+
+## Threat model and scope
+
+hve-squad is a distribution and composition layer for AI agent assets. It ships
+markdown assets, PowerShell build scripts, and CI workflows. It does not run a
+service and holds no user data or secrets.
+
+In scope:
+
+- Prompt-injection paths in the shipped agents, prompts, instructions, and
+  skills, including bypasses of the intake gate, council, and impactful-action
+  gate.
+- Supply-chain weaknesses in the build, release, and plugin publishing
+  workflows.
+- Insecure defaults in the deployed asset set that would grant an agent more
+  capability than intended.
+- Anything in the packaging path that could deliver tampered assets to a
+  consumer's Copilot target.
+
+Out of scope:
+
+- Behaviour of GitHub Copilot, the underlying models, or any MCP server not
+  authored in this repository.
+- Vulnerabilities in third-party dependencies fetched at install time into
+  `apm_modules/` (report upstream, see [NOTICE](NOTICE)).
+- Findings that require a user to deliberately run the squad in an autonomy
+  mode with the gates disabled.
+
+## Security practices in this repository
+
+Every change to `main` goes through pull request validation plus these
+automated controls:
+
+- **CodeQL** static analysis on the Python surface.
+- **Checkov** infrastructure-as-code scanning.
+- **Zizmor** GitHub Actions security analysis, reported to the Security tab.
+- **OpenSSF Scorecard** supply-chain posture analysis, published publicly.
+- **Tiered conformance testing** (Tier 0 conformance, Tier 1 behaviour,
+  Tier 2 semantic) over the shipped agent assets.
+- **Dependabot** weekly updates for GitHub Actions.
+
+All third-party GitHub Actions are pinned to a full commit SHA, workflows
+declare an empty top-level `permissions: {}` and grant the minimum token scope
+per job, and checkouts use `persist-credentials: false`.


### PR DESCRIPTION
Mirrors the badge row from [`microsoft/hve-core`](https://github.com/microsoft/hve-core) and adds the missing artefacts behind it.

## What changed

- `.github/workflows/scorecard.yml`: OpenSSF Scorecard analysis on push to `main`, weekly schedule, and `branch_protection_rule`. Uploads SARIF to the Security tab and sets `publish_results: true` so the public badge resolves.
- `SECURITY.md`: supported versions, private advisory reporting path, threat model and scope (prompt-injection paths, gate bypasses, packaging/supply-chain), and the list of automated controls.
- `.github/dependabot.yml`: weekly grouped GitHub Actions updates. Satisfies Scorecard's `Dependency-Update-Tool` check.
- `README.md`: badge block (PR Validation, CodeQL, Zizmor, Checkov, Scorecard, latest release, license, docs) plus a short Security section.
- `.gitignore`: un-ignore `.github/dependabot.yml`, since `.github/**` is otherwise generated/ignored.

## Repository settings enabled alongside this

Previously all disabled:

- Dependabot alerts and Dependabot security updates
- Secret scanning and push protection
- Private vulnerability reporting

## Follow-up

The OpenSSF Best Practices badge is left commented out in `README.md` until the project is enrolled at <https://www.bestpractices.dev/en/projects/new> and a project ID exists.

## Validation

- Both new YAML files parse cleanly.
- `ossf/scorecard-action` is pinned to the commit SHA behind `v2.4.4` (`2d11466`), consistent with the rest of the repo.
- Workflow declares top-level `permissions: {}`, grants least-privilege per job, and checks out with `persist-credentials: false`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
