### PR TITLE
docs(contributing): document the automated test policy and a standard…

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -38,6 +38,18 @@ No consumer-visible change at all? Ask a maintainer for the `skip-changelog`
 label instead. That skips the version bump too.
 -->
 
+## Tests
+
+<!--
+Major new functionality must come with tests. See "Automated tests" in
+CONTRIBUTING.md. Declare the case in tests/squad-behavior-contract.md first,
+then implement it in the matching tier.
+-->
+
+- [ ] Added or extended an automated test case for the behavior this PR changes, or this PR changes no observable behavior
+- [ ] Declared the case in `tests/squad-behavior-contract.md` with an ID and a citation to the source file stating the rule
+- [ ] Ran `apm run test` (Tier 0) locally and it passed
+
 ## Shared learning sanitization (if proposing a learning)
 
 <!-- Complete only if this PR adds or edits squad-src/.github/skills/squad/learnings/shared-learnings.md. -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,64 @@ A pull request that changes nothing a consumer would notice can carry the `skip-
 
 The full format reference lives in [.changes/README.md](.changes/README.md).
 
+## Automated tests
+
+**Policy: major new functionality must come with tests.** A pull request that
+adds a new agent, a new routing rule, a new gate, or any behavior a consumer can
+observe is expected to add or extend a case in the automated suite covering it.
+Wording fixes, documentation, and pure refactors that change no observable
+behavior are exempt. A maintainer may waive the requirement when a behavior
+genuinely cannot be asserted without a live model run, and says so on the pull
+request.
+
+Cases are declared in
+[tests/squad-behavior-contract.md](tests/squad-behavior-contract.md) before they
+are implemented. Each case cites the source file that states the rule it
+asserts, so a case that cannot cite one is a case that is testing an assumption
+rather than the product. Add your case to the contract, give it an ID in the
+relevant family, then implement it in the matching tier.
+
+The suite is [Pester](https://pester.dev/) 5.7.1 and lives in `tests/`, split
+into three tiers:
+
+| Tier | What it asserts | Spends Copilot requests |
+|------|-----------------|-------------------------|
+| 0    | Static conformance of the installed package: rosters resolve, references exist, prompts bind to delivered agents | no |
+| 1    | Behavioral runs against fixture repos, asserting on state artifacts on disk | yes, for live runs |
+| 2    | Semantic comparison of a run against a golden baseline | yes |
+
+Run the fast suite against the tree your branch would deliver:
+
+```powershell
+apm run test
+```
+
+That is a shortcut for the Tier 0 runner. To invoke the tiers directly:
+
+```powershell
+# Tier 0 — static conformance of this working copy, no requests spent
+./tests/tier0/Invoke-Tier0Tests.ps1 -SourceRoot .
+
+# Tier 0 — a published ref, exactly as a consumer receives it
+./tests/tier0/Invoke-Tier0Tests.ps1 -Ref v0.16.1
+
+# Tier 1 — mutation controls proving the state contract can fail
+./tests/tier1/Invoke-Tier1Tests.ps1 -SelfCheck
+```
+
+Pester 5.7.1 is required and is pinned deliberately; Pester 6 changes `-ForEach`
+and configuration semantics that these suites rely on:
+
+```powershell
+Install-Module Pester -RequiredVersion 5.7.1 -Force -Scope CurrentUser -SkipPublisherCheck
+```
+
+Tier 0 gates every pull request that touches `squad-src/`, `apm.yml`, or
+`tests/tier0/`, and the same workflow is reused as the release gate. Tier 1 and
+Tier 2 are dispatched by hand because they are nondeterministic and cost
+requests. [tests/squad-behavior-contract.md](tests/squad-behavior-contract.md)
+explains that split and records the suite's known gaps.
+
 ## Testing before a release
 
 Releases are cut by hand when the pending work is judged ready, so merging is no longer the moment a change reaches consumers. What merging does reach is the **rolling pre-release**: one GitHub pre-release, rebuilt on every merge to the default branch, tagged with the version the pending fragments currently resolve to.

--- a/apm.yml
+++ b/apm.yml
@@ -313,6 +313,7 @@ dependencies:
   mcp: []
 includes: auto
 scripts:
+  test: "pwsh -NoProfile -ExecutionPolicy Bypass -File tests/tier0/Invoke-Tier0Tests.ps1 -SourceRoot ."
   sync-deps: "pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/Update-ApmDependencies.ps1 -ApmFile apm.yml"
   install-sync: "pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/Update-ApmDependencies.ps1 -ApmFile apm.yml && apm install"
   change: "pwsh -NoProfile -ExecutionPolicy Bypass -File scripts/New-ChangeFragment.ps1"


### PR DESCRIPTION
… test entry point

Adds an Automated tests section to CONTRIBUTING.md stating that major new functionality must come with a test case, explains the three tiers and how to run them locally, and pins the Pester version requirement. Adds a Tests checklist to the pull request template and an 'apm run test' target to apm.yml so the suite has a single standard invocation.

<!-- markdownlint-disable-file MD041 -- GitHub PR templates are injected verbatim into the PR description, so they cannot start with a top-level heading or YAML frontmatter. -->
<!--
Title convention: type(scope): short description
-->

## Summary

<!-- One or two lines describing what this PR does. -->

## Type of change

- [ ] Feature / new content
- [ ] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Change fragment

<!--
Do NOT edit CHANGELOG.md and do NOT bump `version:` in apm.yml. Both are
release outputs assembled on main, and editing them here is exactly what makes
concurrent pull requests conflict. CI rejects a PR that touches either.

Run `apm run change` to create your fragment. See .changes/README.md.
-->

- [ ] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [ ] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [ ] Its body reads as final release notes, not as a commit message
- [ ] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

<!--
A new agent, skill, or role that extends something already shipping is a patch,
however many files it adds. Minor is for the concept, not for the artifacts
built under it. When unsure, pick patch.

No consumer-visible change at all? Ask a maintainer for the `skip-changelog`
label instead. That skips the version bump too.
-->

## Shared learning sanitization (if proposing a learning)

<!-- Complete only if this PR adds or edits squad-src/.github/skills/squad/learnings/shared-learnings.md. -->

- [ ] Remove all secrets, tokens, credentials, and connection strings.
- [ ] Remove customer, organization, and individual names.
- [ ] Remove repository-specific absolute paths and internal URLs.
- [ ] Generalize stack-specific or environment-specific details so the learning applies beyond its origin.
- [ ] Confirm the learning is broadly applicable across consumers and scenarios.

## Notes

<!-- Anything reviewers should know: follow-ups, risks, manual steps. -->
