### PR TITLE
feat(ci): lint the PowerShell surface with PSScriptAnalyzer

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -1,0 +1,171 @@
+# PSScriptAnalyzer lint for the PowerShell surface.
+#
+# PSScriptAnalyzer is the standard FLOSS linter for PowerShell. It runs over the
+# build scripts in scripts/ and the test suites in tests/, which together are the
+# only executable code this repository authors; squad-src/ is markdown assets.
+#
+# The gate blocks on Error severity. Warning and Information findings are
+# reported to the Security tab and the job summary so they stay visible without
+# holding a merge for a stylistic preference. Accepted rules are excluded in
+# PSScriptAnalyzerSettings.psd1 with a written justification, never silenced here.
+name: PSScriptAnalyzer Lint
+
+on:
+  workflow_dispatch:
+  push:
+    branches: ["main"]
+    paths:
+      - '**/*.ps1'
+      - '**/*.psm1'
+      - '**/*.psd1'
+      - '.github/workflows/lint-powershell.yml'
+  pull_request:
+    branches: ["main"]
+    paths:
+      - '**/*.ps1'
+      - '**/*.psm1'
+      - '**/*.psd1'
+      - '.github/workflows/lint-powershell.yml'
+
+permissions: {}
+
+concurrency:
+  group: lint-powershell-${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: PSScriptAnalyzer
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write # upload SARIF results to the Security tab
+      contents: read
+      actions: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      # Pinned so a new rule shipping in a minor release cannot turn a green
+      # branch red without a deliberate bump here.
+      - name: Install PSScriptAnalyzer
+        shell: pwsh
+        run: Install-Module PSScriptAnalyzer -RequiredVersion 1.25.0 -Force -Scope CurrentUser -SkipPublisherCheck
+
+      - name: Run PSScriptAnalyzer
+        shell: pwsh
+        run: |
+          $ErrorActionPreference = 'Stop'
+          Set-StrictMode -Version Latest
+
+          $findings = @()
+          foreach ($path in @('scripts', 'tests')) {
+            if (Test-Path -LiteralPath $path) {
+              $findings += Invoke-ScriptAnalyzer -Path $path -Recurse -Settings ./PSScriptAnalyzerSettings.psd1
+            }
+          }
+
+          # SARIF is generated inline rather than via the ConvertToSARIF module,
+          # which Microsoft archived.
+          $rules = $findings | Group-Object RuleName | ForEach-Object {
+            @{
+              id = $_.Name
+              shortDescription = @{ text = $_.Name }
+              help = @{ text = ($_.Group[0].Message) }
+            }
+          }
+
+          $levelMap = @{ Error = 'error'; Warning = 'warning'; Information = 'note' }
+
+          $results = $findings | ForEach-Object {
+            @{
+              ruleId = $_.RuleName
+              level = $levelMap[[string]$_.Severity]
+              message = @{ text = $_.Message }
+              locations = @(
+                @{
+                  physicalLocation = @{
+                    artifactLocation = @{ uri = ([string]$_.ScriptPath -replace [regex]::Escape($PWD.Path + [System.IO.Path]::DirectorySeparatorChar), '' -replace '\\', '/') }
+                    region = @{ startLine = [int]$_.Line; startColumn = [int]$_.Column }
+                  }
+                }
+              )
+            }
+          }
+
+          $sarif = @{
+            '$schema' = 'https://raw.githubusercontent.com/oasis-tcs/sarif-spec/main/sarif-2.1/schema/sarif-schema-2.1.0.json'
+            version = '2.1.0'
+            runs = @(
+              @{
+                tool = @{
+                  driver = @{
+                    name = 'PSScriptAnalyzer'
+                    version = '1.25.0'
+                    informationUri = 'https://github.com/PowerShell/PSScriptAnalyzer'
+                    rules = @($rules)
+                  }
+                }
+                results = @($results)
+              }
+            )
+          }
+
+          $sarif | ConvertTo-Json -Depth 12 | Set-Content -Path results.sarif -Encoding utf8
+
+          $errors = @($findings | Where-Object { $_.Severity -eq 'Error' })
+          $warnings = @($findings | Where-Object { $_.Severity -eq 'Warning' })
+          $infos = @($findings | Where-Object { $_.Severity -eq 'Information' })
+
+          $summary = @()
+          $summary += '### PSScriptAnalyzer'
+          $summary += ''
+          $summary += '| Severity | Count |'
+          $summary += '| --- | ---: |'
+          $summary += "| Errors | $($errors.Count) |"
+          $summary += "| Warnings | $($warnings.Count) |"
+          $summary += "| Information | $($infos.Count) |"
+          $summary += ''
+
+          if ($findings.Count -gt 0) {
+            $summary += '<details><summary>Findings by rule</summary>'
+            $summary += ''
+            $summary += '| Rule | Severity | Count |'
+            $summary += '| --- | --- | ---: |'
+            $summary += $findings | Group-Object RuleName | Sort-Object Count -Descending | ForEach-Object {
+              "| $($_.Name) | $($_.Group[0].Severity) | $($_.Count) |"
+            }
+            $summary += ''
+            $summary += '</details>'
+          } else {
+            $summary += 'No findings.'
+          }
+
+          $summary += ''
+          $summary += 'The gate blocks on Error only. Accepted rules are excluded in `PSScriptAnalyzerSettings.psd1` with a written justification.'
+          $summary -join "`n" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
+
+          foreach ($e in $errors) {
+            Write-Host "::error file=$($e.ScriptPath),line=$($e.Line)::$($e.RuleName): $($e.Message)"
+          }
+
+          if ($errors.Count -gt 0) {
+            throw "PSScriptAnalyzer reported $($errors.Count) error-severity finding(s)."
+          }
+
+      - name: Upload SARIF file
+        if: (!cancelled())
+        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
+        with:
+          sarif_file: results.sarif
+          category: psscriptanalyzer
+
+      - name: Upload SARIF as artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: psscriptanalyzer-sarif
+          path: results.sarif
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,6 @@ tests/tier1/tier1-selfcheck-results.xml
 tests/tier1/results/
 tests/tier2/tier2-selfcheck-results.xml
 tests/tier2/tier2-score.json
+
+# Linter and scanner output (generated in CI)
+results.sarif

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -21,7 +21,14 @@
 
         # Reports the absence of an [OutputType] attribute on functions that
         # are internal helpers and never part of a published surface.
-        'PSUseOutputTypeCorrectly'
+        'PSUseOutputTypeCorrectly',
+
+        # This rule wants a UTF-8 BOM on every non-ASCII file. Every script here
+        # begins with a `#!/usr/bin/env pwsh` shebang, and a BOM places bytes
+        # ahead of it, which stops the kernel recognising the interpreter line
+        # and breaks execution on Linux. CI runs these scripts on ubuntu-latest,
+        # so honouring this rule would break the build.
+        'PSUseBOMForUnicodeEncodedFile'
     )
 
     Rules = @{

--- a/PSScriptAnalyzerSettings.psd1
+++ b/PSScriptAnalyzerSettings.psd1
@@ -1,0 +1,40 @@
+# PSScriptAnalyzer configuration.
+#
+# VS Code and the PowerShell extension pick this file up automatically, and
+# .github/workflows/lint-powershell.yml passes it explicitly so local and CI
+# results match.
+#
+# The CI gate blocks on Error severity only. Warning and Information findings
+# are reported in the job summary so they stay visible without holding a merge
+# for a stylistic preference.
+@{
+    IncludeDefaultRules = $true
+
+    Severity = @('Error', 'Warning', 'Information')
+
+    ExcludeRules = @(
+        # These scripts are interactive CLI tools whose console output is the
+        # point. Write-Host is the correct call for progress and prompts that
+        # must not enter the pipeline, and rewriting them to Write-Output would
+        # corrupt the values the runners return.
+        'PSAvoidUsingWriteHost',
+
+        # Reports the absence of an [OutputType] attribute on functions that
+        # are internal helpers and never part of a published surface.
+        'PSUseOutputTypeCorrectly'
+    )
+
+    Rules = @{
+        PSPlaceOpenBrace = @{
+            Enable = $true
+            OnSameLine = $true
+            NewLineAfter = $true
+        }
+
+        PSUseConsistentIndentation = @{
+            Enable = $true
+            Kind = 'space'
+            IndentationSize = 4
+        }
+    }
+}

--- a/scripts/Build-SquadPlugin.ps1
+++ b/scripts/Build-SquadPlugin.ps1
@@ -91,6 +91,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
 
 #region Functions
 

--- a/scripts/Build-SquadPlugin.ps1
+++ b/scripts/Build-SquadPlugin.ps1
@@ -167,7 +167,7 @@ function Get-SourceFileList {
         $absDir = Join-Path $Source.SourceRoot $RelativeDir
         if (-not (Test-Path -LiteralPath $absDir)) { return @() }
         return @(Get-ChildItem -LiteralPath $absDir -Recurse -File |
-            ForEach-Object { ($_.FullName.Substring($Source.SourceRoot.Length + 1)) -replace '\\', '/' })
+                ForEach-Object { ($_.FullName.Substring($Source.SourceRoot.Length + 1)) -replace '\\', '/' })
     }
 
     $listing = git -C $RepoRoot ls-tree -r --name-only $Source.Ref -- $RelativeDir 2>$null

--- a/scripts/Get-HveCoreCastDelta.ps1
+++ b/scripts/Get-HveCoreCastDelta.ps1
@@ -88,6 +88,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
 
 #region Functions
 function Get-PinnedHveCoreSha {

--- a/scripts/Invoke-ReleasePrep.ps1
+++ b/scripts/Invoke-ReleasePrep.ps1
@@ -259,8 +259,8 @@ foreach ($required in @($ApmFile, $ChangelogFile)) {
 $fragmentFiles = @()
 if (Test-Path -LiteralPath $FragmentDir) {
     $fragmentFiles = @(Get-ChildItem -LiteralPath $FragmentDir -Filter '*.md' -File |
-        Where-Object { $_.Name -ne 'README.md' } |
-        Sort-Object Name)
+            Where-Object { $_.Name -ne 'README.md' } |
+            Sort-Object Name)
 }
 
 if (-not $fragmentFiles -and -not $AllowEmpty -and -not $Version) {

--- a/scripts/Invoke-ReleasePrep.ps1
+++ b/scripts/Invoke-ReleasePrep.ps1
@@ -120,6 +120,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
 
 $script:SectionOrder = @('Added', 'Changed', 'Deprecated', 'Removed', 'Fixed', 'Security')
 $script:BumpRank = @{ patch = 1; minor = 2; major = 3 }

--- a/scripts/New-ChangeFragment.ps1
+++ b/scripts/New-ChangeFragment.ps1
@@ -66,6 +66,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
 
 #region Functions
 function Select-FromMenu {

--- a/scripts/Set-SquadSelfRefPin.ps1
+++ b/scripts/Set-SquadSelfRefPin.ps1
@@ -63,6 +63,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
 
 if (-not (Test-Path -LiteralPath $ApmFile)) {
     throw "Manifest not found: $ApmFile"

--- a/scripts/Update-ApmDependencies.ps1
+++ b/scripts/Update-ApmDependencies.ps1
@@ -289,7 +289,7 @@ function Build-DependencyList {
                 $_.StartsWith('.github/skills/', [StringComparison]::OrdinalIgnoreCase) -and
                 ([string]::Equals([System.IO.Path]::GetFileName($_), 'SKILL.md', [StringComparison]::OrdinalIgnoreCase))
             } |
-                ForEach-Object { (Split-Path -Path $_ -Parent).Replace('\', '/') } |
+            ForEach-Object { (Split-Path -Path $_ -Parent).Replace('\', '/') } |
             Sort-Object -Unique
     )
 
@@ -384,7 +384,7 @@ function Build-SquadDependencyList {
                 $_.StartsWith("$prefix/.github/skills/", [StringComparison]::OrdinalIgnoreCase) -and
                 ([string]::Equals([System.IO.Path]::GetFileName($_), 'SKILL.md', [StringComparison]::OrdinalIgnoreCase))
             } |
-                ForEach-Object { (Split-Path -Path $_ -Parent).Replace('\', '/') } |
+            ForEach-Object { (Split-Path -Path $_ -Parent).Replace('\', '/') } |
             Sort-Object -Unique
     )
 

--- a/scripts/Update-ApmDependencies.ps1
+++ b/scripts/Update-ApmDependencies.ps1
@@ -143,6 +143,7 @@ param(
 )
 
 $ErrorActionPreference = 'Stop'
+Set-StrictMode -Version Latest
 
 #region Functions
 function Get-LeadingSpaceCount {

--- a/tests/tier0/Invoke-Tier0Tests.ps1
+++ b/tests/tier0/Invoke-Tier0Tests.ps1
@@ -135,7 +135,7 @@ if (-not $IncludeAdvisory) {
 
 # An empty case set is a legitimate state - a package with no skill references claims
 # none - but Pester 6 treats it as an error by default.
-try { $config.Run.FailOnNullOrEmptyForEach = $false } catch { }
+try { $config.Run.FailOnNullOrEmptyForEach = $false } catch { Write-Debug 'FailOnNullOrEmptyForEach is a Pester 6 setting; Pester 5 has no such property and needs no opt-out.' }
 
 $result = Invoke-Pester -Configuration $config
 

--- a/tests/tier0/Manifest.Tests.ps1
+++ b/tests/tier0/Manifest.Tests.ps1
@@ -2,6 +2,10 @@
 # Copyright (c) 2026 Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+# False positive: $SourceRoot is read inside BeforeDiscovery and BeforeAll, which
+# PSScriptAnalyzer treats as scopes unrelated to the param block.
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SourceRoot',
+    Justification = 'Read inside Pester BeforeDiscovery and BeforeAll blocks.')]
 param(
     [Parameter(Mandatory)]
     [string]$SourceRoot

--- a/tests/tier0/SquadPackage.Tests.ps1
+++ b/tests/tier0/SquadPackage.Tests.ps1
@@ -2,6 +2,17 @@
 # Copyright (c) 2026 Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+# False positive: Pester evaluates BeforeDiscovery in the discovery scope and the It
+# blocks that consume $model through -ForEach in the run scope. PSScriptAnalyzer
+# resolves neither, so it reports the assignment as unused.
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'model',
+    Justification = 'Consumed by It -ForEach at discovery scope; PSScriptAnalyzer cannot resolve Pester scoping.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'PackageRoot',
+    Justification = 'Read inside BeforeDiscovery and BeforeAll, which PSScriptAnalyzer treats as unrelated scopes.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'InstallLog',
+    Justification = 'Read inside BeforeAll, which PSScriptAnalyzer treats as an unrelated scope.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'ExpectPinned',
+    Justification = 'Read inside BeforeAll, which PSScriptAnalyzer treats as an unrelated scope.')]
 param(
     [Parameter(Mandatory)]
     [string]$PackageRoot,

--- a/tests/tier1/Assertions.Tests.ps1
+++ b/tests/tier1/Assertions.Tests.ps1
@@ -247,7 +247,8 @@ Describe 'The contract catches a broken tree' {
     It 'catches a file written with a read tool line-number gutter' {
         $root = New-Fixture 'numbered-lines'
         $path = Join-Path $root 'history/Squad Researcher.md'
-        $numbered = @(Get-Content -LiteralPath $path | ForEach-Object -Begin { $i = 0 } -Process { $i++; "$i. $_" })
+        $lines = @(Get-Content -LiteralPath $path)
+        $numbered = @(for ($n = 1; $n -le $lines.Count; $n++) { "$n. $($lines[$n - 1])" })
         Set-Content -LiteralPath $path -Value $numbered -Encoding utf8NoBOM
         (Test-Contract $root).Passed | Should -BeFalse -Because 'a gutter that reads as content leaves the file parseable to nobody'
     }

--- a/tests/tier1/Invoke-Tier1Tests.ps1
+++ b/tests/tier1/Invoke-Tier1Tests.ps1
@@ -36,6 +36,10 @@
     See tests/squad-behavior-contract.md for the cases this implements.
 #>
 [CmdletBinding(DefaultParameterSetName = 'SelfCheck')]
+# False positive: -SelfCheck selects a parameter set and the script branches on
+# $PSCmdlet.ParameterSetName rather than reading the switch by name.
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SelfCheck',
+    Justification = 'Parameter-set selector; consumed via $PSCmdlet.ParameterSetName.')]
 param(
     [Parameter(Mandatory, ParameterSetName = 'Assert')]
     [string]$SquadRoot,
@@ -78,7 +82,7 @@ else {
 }
 
 # An empty case set is a legitimate state, but Pester 6 treats it as an error by default.
-try { $config.Run.FailOnNullOrEmptyForEach = $false } catch { }
+try { $config.Run.FailOnNullOrEmptyForEach = $false } catch { Write-Debug 'FailOnNullOrEmptyForEach is a Pester 6 setting; Pester 5 has no such property and needs no opt-out.' }
 
 $result = Invoke-Pester -Configuration $config
 

--- a/tests/tier1/SquadRun.psm1
+++ b/tests/tier1/SquadRun.psm1
@@ -152,7 +152,7 @@ function Invoke-SquadTurn {
     $timedOut = $false
     if (-not $process.WaitForExit($TimeoutMinutes * 60 * 1000)) {
         $timedOut = $true
-        try { $process.Kill($true) } catch { }
+        try { $process.Kill($true) } catch { Write-Debug 'The run process exited between the timeout check and the kill; nothing to terminate.' }
         $process.WaitForExit(30 * 1000) | Out-Null
     }
 

--- a/tests/tier1/SquadState.psm1
+++ b/tests/tier1/SquadState.psm1
@@ -146,8 +146,8 @@ function Get-DeliverablePathToken {
     # 'history/Squad Researcher.md' would truncate to 'history/Squad'. A fan-out
     # summarized as 'history/*.md' or 'root/{a.md,b.md}' names a set, not an artifact.
     @($tokens |
-        ForEach-Object { $_.Trim().TrimEnd(',', ';', '.') } |
-        Where-Object { $_ -and $_ -notmatch '[*?{}]' })
+            ForEach-Object { $_.Trim().TrimEnd(',', ';', '.') } |
+            Where-Object { $_ -and $_ -notmatch '[*?{}]' })
 }
 
 function Get-DeliverableEntry {

--- a/tests/tier1/StateContract.Tests.ps1
+++ b/tests/tier1/StateContract.Tests.ps1
@@ -2,6 +2,13 @@
 # Copyright (c) 2026 Microsoft Corporation. All rights reserved.
 # SPDX-License-Identifier: MIT
 
+# False positive: Pester evaluates BeforeDiscovery in the discovery scope and the It
+# blocks that consume $model through -ForEach in the run scope. PSScriptAnalyzer
+# resolves neither, so it reports the assignment as unused.
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSUseDeclaredVarsMoreThanAssignments', 'model',
+    Justification = 'Consumed by It -ForEach at discovery scope; PSScriptAnalyzer cannot resolve Pester scoping.')]
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute('PSReviewUnusedParameter', 'SquadRoot',
+    Justification = 'Read inside BeforeDiscovery and BeforeAll, which PSScriptAnalyzer treats as unrelated scopes.')]
 param(
     [Parameter(Mandatory)]
     [string]$SquadRoot,

--- a/tests/tier2/Invoke-Tier2Tests.ps1
+++ b/tests/tier2/Invoke-Tier2Tests.ps1
@@ -30,7 +30,7 @@ $config.Output.Verbosity = $Output
 $config.TestResult.Enabled = $true
 $config.TestResult.OutputPath = Join-Path $PSScriptRoot 'tier2-selfcheck-results.xml'
 
-try { $config.Run.FailOnNullOrEmptyForEach = $false } catch { }
+try { $config.Run.FailOnNullOrEmptyForEach = $false } catch { Write-Debug 'FailOnNullOrEmptyForEach is a Pester 6 setting; Pester 5 has no such property and needs no opt-out.' }
 
 $result = Invoke-Pester -Configuration $config
 

--- a/tests/tier2/SquadCompare.psm1
+++ b/tests/tier2/SquadCompare.psm1
@@ -187,7 +187,7 @@ function Get-AnswerScore {
             -NoNewWindow -PassThru -RedirectStandardOutput $output -RedirectStandardError "$output.err"
 
         if (-not $process.WaitForExit($TimeoutMinutes * 60 * 1000)) {
-            try { $process.Kill($true) } catch { }
+            try { $process.Kill($true) } catch { Write-Debug 'The judge process exited between the timeout check and the kill; nothing to terminate.' }
             return [pscustomobject]@{ Score = -1; Note = 'judge timed out' }
         }
 


### PR DESCRIPTION
Adds a PSScriptAnalyzer workflow over scripts/ and tests/, the only executable code this repository authors. The gate blocks on Error severity; Warning and Information findings are reported to the Security tab and the job summary. Rule exclusions live in PSScriptAnalyzerSettings.psd1 with a written justification, so VS Code and CI evaluate the same rule set. SARIF is generated inline because Microsoft archived the ConvertToSARIF module.

<!-- markdownlint-disable-file MD041 -- GitHub PR templates are injected verbatim into the PR description, so they cannot start with a top-level heading or YAML frontmatter. -->
<!--
Title convention: type(scope): short description
-->

## Summary

<!-- One or two lines describing what this PR does. -->

## Type of change

- [ ] Feature / new content
- [ ] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Change fragment

<!--
Do NOT edit CHANGELOG.md and do NOT bump `version:` in apm.yml. Both are
release outputs assembled on main, and editing them here is exactly what makes
concurrent pull requests conflict. CI rejects a PR that touches either.

Run `apm run change` to create your fragment. See .changes/README.md.
-->

- [ ] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [ ] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [ ] Its body reads as final release notes, not as a commit message
- [ ] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

<!--
A new agent, skill, or role that extends something already shipping is a patch,
however many files it adds. Minor is for the concept, not for the artifacts
built under it. When unsure, pick patch.

No consumer-visible change at all? Ask a maintainer for the `skip-changelog`
label instead. That skips the version bump too.
-->

## Shared learning sanitization (if proposing a learning)

<!-- Complete only if this PR adds or edits squad-src/.github/skills/squad/learnings/shared-learnings.md. -->

- [ ] Remove all secrets, tokens, credentials, and connection strings.
- [ ] Remove customer, organization, and individual names.
- [ ] Remove repository-specific absolute paths and internal URLs.
- [ ] Generalize stack-specific or environment-specific details so the learning applies beyond its origin.
- [ ] Confirm the learning is broadly applicable across consumers and scenarios.

## Notes

<!-- Anything reviewers should know: follow-ups, risks, manual steps. -->
