### PR TITLE
feat(issues): add a bug report template and document the reporting pr…

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,78 @@
+name: Bug report
+description: Report something in hve-squad that does not behave as documented.
+title: "[bug] "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Two things first:
+
+        - **Security vulnerabilities do not belong here.** Report them privately through
+          [security advisories](https://github.com/Peter-N91/hve-squad/security/advisories/new).
+          See [SECURITY.md](https://github.com/Peter-N91/hve-squad/blob/main/SECURITY.md).
+        - **Want the squad to do work for you?** Use the *Squad task* template instead.
+
+        hve-squad composes assets from
+        [microsoft/hve-core](https://github.com/microsoft/hve-core). If the problem is in an
+        hve-core agent rather than in how hve-squad packages or routes it, that repository is
+        the better place. When in doubt, file here and it will be redirected.
+
+  - type: input
+    id: version
+    attributes:
+      label: Version
+      description: The ref you installed. Run `apm list` if you are unsure.
+      placeholder: e.g. v0.16.1, or v0.16.2-pre
+    validations:
+      required: true
+
+  - type: dropdown
+    id: host
+    attributes:
+      label: Host
+      description: Where the squad was running.
+      options:
+        - GitHub Copilot CLI
+        - VS Code (Copilot Chat)
+        - GitHub.com (Copilot coding agent)
+        - Other or unsure
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: What you expected
+      description: Cite the documentation, instruction file, or roster rule that says so, if you can.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: What happened instead
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1. apm install "Peter-N91/hve-squad#v0.16.1" --target copilot
+        2. /squad request="..."
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: state
+    attributes:
+      label: Squad state (optional)
+      description: |
+        The contents of `team.md` or `federation.md`, and the relevant `history/` entry, are usually
+        what pins a routing or ledger defect down. Remove anything you do not want public.
+      render: markdown
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Report a security vulnerability
+    url: https://github.com/Peter-N91/hve-squad/security/advisories/new
+    about: Report privately through GitHub Security Advisories. Do not open a public issue.
+  - name: Documentation
+    url: https://peter-n91.github.io/hve-squad/
+    about: Getting started, usage, maintaining, and troubleshooting guides.
+  - name: Issue in an upstream hve-core asset
+    url: https://github.com/microsoft/hve-core/issues
+    about: hve-squad composes hve-core agents, prompts, instructions, and skills.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,6 +3,29 @@ title: Contributing to hve-squad
 description: How changes reach the hve-squad package and how to promote a sanitized shared learning through the fork and pull request review gate.
 ---
 
+## Reporting a bug
+
+Open an issue at
+[github.com/Peter-N91/hve-squad/issues](https://github.com/Peter-N91/hve-squad/issues)
+using the **Bug report** template. It asks for the version, the host you ran on,
+what you expected against what happened, and steps to reproduce. Squad state
+(`team.md` or `federation.md`, plus the relevant `history/` entry) is usually
+what pins a routing or ledger defect down, so include it when you can.
+
+Issues are triaged by a maintainer. There is no service-level agreement on a
+solo-maintained project, but a report that reproduces gets a response.
+
+Two things do not belong in a public issue:
+
+* **Security vulnerabilities.** Report them privately through
+  [security advisories](https://github.com/Peter-N91/hve-squad/security/advisories/new).
+  See [SECURITY.md](SECURITY.md).
+* **Defects in an upstream dependency.**
+  [microsoft/hve-core](https://github.com/microsoft/hve-core/issues) owns the
+  agents, prompts, instructions, and skills that hve-squad composes. If the
+  problem is in how hve-squad packages or routes one of them, it belongs here.
+  When in doubt, file here and it will be redirected.
+
 ## How contributions reach the package
 
 hve-squad gets better when a durable fix found in one environment reaches every other consumer hitting the same scenario. hve-squad ships through APM as one-directional package content: consumers pull the package, and the package never reads from consumer environments. The only route for a change to reach the published package is a fork and pull request against this repository.


### PR DESCRIPTION
…ocess

The two existing templates cover proposing a shared learning and handing a task to the squad, so a user with a defect had no route but a blank issue. Adds a Bug report form asking for version, host, expected against actual, reproduction steps, and squad state, plus an ISSUE_TEMPLATE config that routes vulnerabilities to private security advisories and upstream asset defects to microsoft/hve-core. CONTRIBUTING.md now opens with how to report a bug rather than assuming every reader arrives with a pull request.

<!-- markdownlint-disable-file MD041 -- GitHub PR templates are injected verbatim into the PR description, so they cannot start with a top-level heading or YAML frontmatter. -->
<!--
Title convention: type(scope): short description
-->

## Summary

<!-- One or two lines describing what this PR does. -->

## Type of change

- [ ] Feature / new content
- [ ] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Change fragment

<!--
Do NOT edit CHANGELOG.md and do NOT bump `version:` in apm.yml. Both are
release outputs assembled on main, and editing them here is exactly what makes
concurrent pull requests conflict. CI rejects a PR that touches either.

Run `apm run change` to create your fragment. See .changes/README.md.
-->

- [ ] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [ ] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [ ] Its body reads as final release notes, not as a commit message
- [ ] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

<!--
A new agent, skill, or role that extends something already shipping is a patch,
however many files it adds. Minor is for the concept, not for the artifacts
built under it. When unsure, pick patch.

No consumer-visible change at all? Ask a maintainer for the `skip-changelog`
label instead. That skips the version bump too.
-->

## Shared learning sanitization (if proposing a learning)

<!-- Complete only if this PR adds or edits squad-src/.github/skills/squad/learnings/shared-learnings.md. -->

- [ ] Remove all secrets, tokens, credentials, and connection strings.
- [ ] Remove customer, organization, and individual names.
- [ ] Remove repository-specific absolute paths and internal URLs.
- [ ] Generalize stack-specific or environment-specific details so the learning applies beyond its origin.
- [ ] Confirm the learning is broadly applicable across consumers and scenarios.

## Notes

<!-- Anything reviewers should know: follow-ups, risks, manual steps. -->
