### PR TITLE
fix(ci): stop flooding the Security tab with posture and style findings

### DIFF
--- a/.github/workflows/lint-powershell.yml
+++ b/.github/workflows/lint-powershell.yml
@@ -4,10 +4,16 @@
 # build scripts in scripts/ and the test suites in tests/, which together are the
 # only executable code this repository authors; squad-src/ is markdown assets.
 #
-# The gate blocks on Error severity. Warning and Information findings are
-# reported to the Security tab and the job summary so they stay visible without
-# holding a merge for a stylistic preference. Accepted rules are excluded in
-# PSScriptAnalyzerSettings.psd1 with a written justification, never silenced here.
+# The gate blocks on Error severity. Every finding, at every severity, is listed
+# in the job summary and kept as an artifact.
+#
+# Only findings from the security rule set below (or any Error-severity finding)
+# are uploaded to the Security tab. PSScriptAnalyzer is mostly a style and
+# quality linter, and publishing singular-noun or comment-help findings as code
+# scanning alerts buries real security findings under naming advice.
+#
+# Accepted rules are excluded in PSScriptAnalyzerSettings.psd1 with a written
+# justification, never silenced here.
 name: PSScriptAnalyzer Lint
 
 on:
@@ -69,7 +75,27 @@ jobs:
 
           # SARIF is generated inline rather than via the ConvertToSARIF module,
           # which Microsoft archived.
-          $rules = $findings | Group-Object RuleName | ForEach-Object {
+          #
+          # Only security-relevant rules reach the Security tab. Style and
+          # quality findings stay in the job summary below, where they belong.
+          $securityRules = @(
+            'PSAvoidUsingPlainTextForPassword'
+            'PSAvoidUsingConvertToSecureStringWithPlainText'
+            'PSAvoidUsingUsernameAndPasswordParams'
+            'PSUsePSCredentialType'
+            'PSAvoidUsingInvokeExpression'
+            'PSAvoidUsingComputerNameHardcoded'
+            'PSAvoidUsingBrokenHashAlgorithms'
+            'PSUseSupportsShouldProcess'
+            'PSAvoidUsingWMICmdlet'
+            'PSAvoidUsingEmptyCatchBlock'
+          )
+
+          $publishable = @($findings | Where-Object {
+            $_.Severity -eq 'Error' -or $securityRules -contains $_.RuleName
+          })
+
+          $rules = $publishable | Group-Object RuleName | ForEach-Object {
             @{
               id = $_.Name
               shortDescription = @{ text = $_.Name }
@@ -79,7 +105,7 @@ jobs:
 
           $levelMap = @{ Error = 'error'; Warning = 'warning'; Information = 'note' }
 
-          $results = $findings | ForEach-Object {
+          $results = $publishable | ForEach-Object {
             @{
               ruleId = $_.RuleName
               level = $levelMap[[string]$_.Severity]
@@ -144,7 +170,7 @@ jobs:
           }
 
           $summary += ''
-          $summary += 'The gate blocks on Error only. Accepted rules are excluded in `PSScriptAnalyzerSettings.psd1` with a written justification.'
+          $summary += "Published to the Security tab: $($publishable.Count) security-relevant finding(s). The gate blocks on Error only. Accepted rules are excluded in ``PSScriptAnalyzerSettings.psd1`` with a written justification."
           $summary -join "`n" | Add-Content -LiteralPath $env:GITHUB_STEP_SUMMARY
 
           foreach ($e in $errors) {

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,6 +1,13 @@
-# OpenSSF Scorecard supply-chain posture analysis. Results are uploaded to the
-# Security tab and published to the public OpenSSF API, which is what backs the
-# Scorecard badge in README.md.
+# OpenSSF Scorecard supply-chain posture analysis. Results are published to the
+# public OpenSSF API, which is what backs the Scorecard badge in README.md, and
+# kept as a build artifact.
+#
+# Results are deliberately NOT uploaded to the Security tab. Scorecard reports
+# posture checks (Fuzzing, Branch-Protection, Maintained, Pinned-Dependencies)
+# at error severity, and those are standing recommendations rather than defects
+# with a fix, so surfacing them as code-scanning alerts leaves the Security tab
+# permanently red and buries genuine findings. The score is read from the badge
+# and from https://scorecard.dev instead.
 name: OpenSSF Scorecard
 
 on:
@@ -22,7 +29,6 @@ jobs:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
-      security-events: write # upload the SARIF result to the Security tab
       id-token: write # publish results to the OpenSSF API (badge data)
       contents: read
       actions: read
@@ -47,10 +53,3 @@ jobs:
           name: scorecard-sarif
           path: results.sarif
           retention-days: 30
-
-      - name: Upload SARIF file
-        if: (!cancelled())
-        uses: github/codeql-action/upload-sarif@7211b7c8077ea37d8641b6271f6a365a22a5fbfa # v4.36.0
-        with:
-          sarif_file: results.sarif
-          category: scorecard


### PR DESCRIPTION
The Security tab held 31 alerts, 30 of which were not defects. Scorecard reports posture checks (Fuzzing, Branch-Protection, Maintained, Pinned-Dependencies) at error severity; those are standing recommendations with no fix, so the SARIF upload is removed and the score is read from the badge and scorecard.dev instead. The workflow keeps publish_results for the badge and drops the now-unused security-events permission. PSScriptAnalyzer now publishes only security-rule and Error-severity findings; style and quality findings stay in the job summary and the artifact, where the full set is still visible.

<!-- markdownlint-disable-file MD041 -- GitHub PR templates are injected verbatim into the PR description, so they cannot start with a top-level heading or YAML frontmatter. -->
<!--
Title convention: type(scope): short description
-->

## Summary

<!-- One or two lines describing what this PR does. -->

## Type of change

- [ ] Feature / new content
- [ ] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Change fragment

<!--
Do NOT edit CHANGELOG.md and do NOT bump `version:` in apm.yml. Both are
release outputs assembled on main, and editing them here is exactly what makes
concurrent pull requests conflict. CI rejects a PR that touches either.

Run `apm run change` to create your fragment. See .changes/README.md.
-->

- [ ] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [ ] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [ ] Its body reads as final release notes, not as a commit message
- [ ] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

<!--
A new agent, skill, or role that extends something already shipping is a patch,
however many files it adds. Minor is for the concept, not for the artifacts
built under it. When unsure, pick patch.

No consumer-visible change at all? Ask a maintainer for the `skip-changelog`
label instead. That skips the version bump too.
-->

## Tests

<!--
Major new functionality must come with tests. See "Automated tests" in
CONTRIBUTING.md. Declare the case in tests/squad-behavior-contract.md first,
then implement it in the matching tier.
-->

- [ ] Added or extended an automated test case for the behavior this PR changes, or this PR changes no observable behavior
- [ ] Declared the case in `tests/squad-behavior-contract.md` with an ID and a citation to the source file stating the rule
- [ ] Ran `apm run test` (Tier 0) locally and it passed

## Shared learning sanitization (if proposing a learning)

<!-- Complete only if this PR adds or edits squad-src/.github/skills/squad/learnings/shared-learnings.md. -->

- [ ] Remove all secrets, tokens, credentials, and connection strings.
- [ ] Remove customer, organization, and individual names.
- [ ] Remove repository-specific absolute paths and internal URLs.
- [ ] Generalize stack-specific or environment-specific details so the learning applies beyond its origin.
- [ ] Confirm the learning is broadly applicable across consumers and scenarios.

## Notes

<!-- Anything reviewers should know: follow-ups, risks, manual steps. -->
