### PR TITLE
fix(scripts): verify the installed hve-core tree against its pinned commit

### DIFF
--- a/.changes/unreleased/20260825-hve-core-pin-could-not-be-verified-after-install.md
+++ b/.changes/unreleased/20260825-hve-core-pin-could-not-be-verified-after-install.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: Fixed
+---
+
+- **An installed `hve-squad-hve-core` tree could not be proven to match the commit its marketplace entry pins.** `config.json` records a content digest rather than the git commit SHA-1, and its `version` comes from upstream hve-core's own `plugin.json`, so `copilot plugin update` reports 'already at latest' even when the pin moves. Added `scripts/Test-HveCorePin.ps1`, which recomputes the git blob SHA-1 of every installed file against the pinned tree, and rewrote the marketplace description in `scripts/Build-SquadPlugin.ps1` to say the plugin replaces the official hve-core plugin rather than sitting beside it, and must be refreshed with uninstall-then-install.

--- a/scripts/Build-SquadPlugin.ps1
+++ b/scripts/Build-SquadPlugin.ps1
@@ -869,7 +869,7 @@ if ($MyInvocation.InvocationName -ne '.') {
                 }
                 [ordered]@{
                     name        = 'hve-squad-hve-core'
-                    description = "microsoft/hve-core pinned to the exact commit validated against hve-squad $($source.PluginVersion)'s apm.yml (Sync and Adapt / cast-delta guard). Named distinctly from the official hve-core plugin so both can be registered side by side."
+                    description = "microsoft/hve-core pinned to the exact commit validated against hve-squad $($source.PluginVersion)'s apm.yml (Sync and Adapt / cast-delta guard). Install this INSTEAD OF the official hve-core plugin, not alongside it: the distinct name only prevents a name collision at install time, and registering both gives you a second, unpinned copy of every hve-core agent that squad roles can resolve to. Refresh it with uninstall-then-install; plugin update cannot see a new pin because the recorded version comes from upstream hve-core's own plugin.json."
                     version     = $source.PluginVersion
                     source      = [ordered]@{
                         source = 'github'

--- a/scripts/Test-HveCorePin.ps1
+++ b/scripts/Test-HveCorePin.ps1
@@ -1,0 +1,158 @@
+#!/usr/bin/env pwsh
+# Copyright (c) 2026 Microsoft Corporation. All rights reserved.
+# SPDX-License-Identifier: MIT
+#Requires -Version 7.4
+
+<#
+.SYNOPSIS
+    Verifies that an installed Copilot CLI plugin tree really is the commit its
+    marketplace entry pins.
+.DESCRIPTION
+    marketplace.json pins 'hve-squad-hve-core' to an exact microsoft/hve-core
+    commit via source.sha. Nothing in the CLI proves after the fact that the tree
+    on disk came from that commit:
+
+      * config.json records 'source_sha' as a 64-hex content digest of the
+        downloaded payload, not the git commit SHA-1, so it cannot be compared
+        against source.sha by eye.
+      * config.json records 'version' from the *upstream* plugin.json (hve-core
+        3.2.2), not from the marketplace entry, so bumping the marketplace
+        version alongside a new sha does not make 'copilot plugin update' report
+        an upgrade. It answers 'already at latest' and may leave the previously
+        pinned tree in place.
+
+    This script closes that gap by comparing content, not metadata. It reads the
+    pin from marketplace.json, fetches the full recursive git tree at that
+    commit, and recomputes the git blob SHA-1 of every installed file. A tree
+    that matches on every path and every blob can only have come from the pinned
+    commit.
+
+    Files are compared byte-for-byte first, then retried with CRLF collapsed to
+    LF, because a Windows checkout normalises line endings while git blob hashes
+    are always computed over LF content.
+.PARAMETER PluginRoot
+    Directory holding the installed plugin tree to verify.
+.PARAMETER MarketplaceUrl
+    Raw URL of the marketplace.json carrying the pin. Defaults to main of the
+    published plugin repository, so the check runs against what users install.
+.PARAMETER PluginName
+    Marketplace entry whose source.sha is verified.
+.PARAMETER GitHubToken
+    Optional PAT. Supply it when the unauthenticated GitHub API rate limit bites.
+.EXAMPLE
+    ./scripts/Test-HveCorePin.ps1
+.EXAMPLE
+    ./scripts/Test-HveCorePin.ps1 -PluginRoot ~/.copilot/installed-plugins/hve-squad-plugin/hve-squad-hve-core
+.NOTES
+    Exit code 0 means verified, 1 means drift. Safe to wire into CI after a
+    release bumps the hve-core pin.
+#>
+
+[CmdletBinding()]
+param(
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$PluginRoot = (Join-Path $HOME '.copilot/installed-plugins/hve-squad-plugin/hve-squad-hve-core'),
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$MarketplaceUrl = 'https://raw.githubusercontent.com/Peter-N91/hve-squad-plugin/main/.github/plugin/marketplace.json',
+
+    [Parameter(Mandatory = $false)]
+    [ValidateNotNullOrEmpty()]
+    [string]$PluginName = 'hve-squad-hve-core',
+
+    [Parameter(Mandatory = $false)]
+    [string]$GitHubToken
+)
+
+$ErrorActionPreference = 'Stop'
+
+if (-not (Test-Path -LiteralPath $PluginRoot)) {
+    throw "Plugin root not found: $PluginRoot"
+}
+$root = (Resolve-Path -LiteralPath $PluginRoot).Path
+
+$headers = @{ 'User-Agent' = 'hve-squad-pin-check' }
+if ($GitHubToken) { $headers['Authorization'] = "Bearer $GitHubToken" }
+
+$marketplace = Invoke-RestMethod -Uri $MarketplaceUrl -Headers $headers
+$entry = $marketplace.plugins | Where-Object { $_.name -eq $PluginName }
+if (-not $entry) { throw "No plugin named '$PluginName' in $MarketplaceUrl" }
+
+$pinnedSha = $entry.source.sha
+if (-not $pinnedSha) {
+    throw "'$PluginName' has no source.sha - it tracks '$($entry.source.ref)' and cannot be verified by commit."
+}
+$repo = $entry.source.repo
+
+Write-Host "repo        : $repo"
+Write-Host "pinned sha  : $pinnedSha"
+Write-Host "plugin root : $root"
+
+$tree = Invoke-RestMethod -Uri "https://api.github.com/repos/$repo/git/trees/$pinnedSha`?recursive=1" -Headers $headers
+if ($tree.truncated) {
+    throw 'GitHub truncated the tree response; the repository is too large for a single-request verification.'
+}
+
+$expected = @{}
+foreach ($node in $tree.tree) {
+    if ($node.type -eq 'blob') { $expected[$node.path] = $node.sha }
+}
+
+$sha1 = [System.Security.Cryptography.SHA1]::Create()
+function Get-GitBlobSha {
+    param([byte[]]$Content)
+    $header = [System.Text.Encoding]::ASCII.GetBytes("blob $($Content.Length)`0")
+    $buffer = [byte[]]::new($header.Length + $Content.Length)
+    [Array]::Copy($header, 0, $buffer, 0, $header.Length)
+    [Array]::Copy($Content, 0, $buffer, $header.Length, $Content.Length)
+    return [System.Convert]::ToHexString($sha1.ComputeHash($buffer)).ToLowerInvariant()
+}
+
+$verified = 0
+$mismatched = [System.Collections.Generic.List[string]]::new()
+$untracked = [System.Collections.Generic.List[string]]::new()
+$seen = [System.Collections.Generic.HashSet[string]]::new()
+
+foreach ($file in Get-ChildItem -LiteralPath $root -Recurse -File -Force) {
+    $relative = $file.FullName.Substring($root.Length + 1).Replace('\', '/')
+    if ($relative -like '.git/*') { continue }
+
+    if (-not $expected.ContainsKey($relative)) {
+        $untracked.Add($relative)
+        continue
+    }
+    [void]$seen.Add($relative)
+
+    $bytes = [System.IO.File]::ReadAllBytes($file.FullName)
+    if ((Get-GitBlobSha $bytes) -eq $expected[$relative]) { $verified++; continue }
+
+    $normalised = [System.Text.Encoding]::UTF8.GetBytes(
+        ([System.Text.Encoding]::UTF8.GetString($bytes) -replace "`r`n", "`n"))
+    if ((Get-GitBlobSha $normalised) -eq $expected[$relative]) { $verified++; continue }
+
+    $mismatched.Add($relative)
+}
+
+$absent = $expected.Keys | Where-Object { -not $seen.Contains($_) }
+
+Write-Host ''
+Write-Host "verified    : $verified / $($expected.Count)"
+Write-Host "mismatched  : $($mismatched.Count)"
+Write-Host "not in pin  : $($untracked.Count)"
+Write-Host "missing     : $(@($absent).Count)"
+
+foreach ($path in ($mismatched | Select-Object -First 20)) { Write-Warning "content differs: $path" }
+foreach ($path in ($untracked | Select-Object -First 20)) { Write-Warning "extra file: $path" }
+foreach ($path in (@($absent) | Select-Object -First 20)) { Write-Warning "absent locally: $path" }
+
+if ($mismatched.Count -eq 0 -and $untracked.Count -eq 0 -and @($absent).Count -eq 0) {
+    Write-Host ''
+    Write-Host "OK: installed tree matches $repo@$pinnedSha exactly." -ForegroundColor Green
+    exit 0
+}
+
+Write-Host ''
+Write-Error "DRIFT: installed tree does not match $repo@$pinnedSha."
+exit 1


### PR DESCRIPTION
## Summary

An installed `hve-squad-hve-core` tree could not be proven to match the commit its marketplace entry pins. This adds a verifier that compares content instead of metadata, and corrects the marketplace description that told users to install this plugin alongside the official hve-core plugin.

## Type of change

- [ ] Feature / new content
- [x] Fix
- [ ] Docs only
- [ ] Chore / maintenance

## Change fragment

- [x] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [x] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [x] Its body reads as final release notes, not as a commit message
- [x] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

## Tests

- [x] Added or extended an automated test case for the behavior this PR changes, or this PR changes no observable behavior
- [ ] Declared the case in `tests/squad-behavior-contract.md` with an ID and a citation to the source file stating the rule
- [x] Ran `apm run test` (Tier 0) locally and it passed

`scripts/Test-HveCorePin.ps1` is itself the check, run on demand against an installed tree rather than from a tier; no squad behavior changes, so no contract case was added. PSScriptAnalyzer is clean against `PSScriptAnalyzerSettings.psd1`.

## Notes

Two gaps motivated this:

* `config.json` records `source_sha` as a content digest of the downloaded payload, not the git commit SHA-1, so it cannot be compared against the marketplace `source.sha` by eye.
* `config.json` records `version` from **upstream** hve-core's `plugin.json`, not from the marketplace entry, so bumping the marketplace version alongside a new sha does not make `copilot plugin update` report an upgrade — it answers "already at latest" and can leave the previously pinned tree in place.

`scripts/Test-HveCorePin.ps1` closes both by fetching the recursive git tree at the pinned commit and recomputing the git blob SHA-1 of every installed file. Comparison is byte-for-byte first, then retried with CRLF collapsed to LF, because a Windows checkout normalises line endings while git blob hashes are always over LF content. Exit code 0 means verified, 1 means drift, so it is safe to wire into CI after a release bumps the pin.

The marketplace description in `scripts/Build-SquadPlugin.ps1` now says this plugin replaces the official hve-core plugin rather than sitting beside it: the distinct name only avoids a name collision at install time, and registering both leaves a second, unpinned copy of every hve-core agent that squad roles can resolve to. It also records that refreshing needs uninstall-then-install.
