### PR TITLE
docs: document the MCP server and Copilot CLI plugin siblings

### DIFF
--- a/.changes/unreleased/20260826-document-the-mcp-server-and-copilot-cli-plugin.md
+++ b/.changes/unreleased/20260826-document-the-mcp-server-and-copilot-cli-plugin.md
@@ -1,0 +1,6 @@
+---
+bump: patch
+type: Added
+---
+
+- **The documentation never pointed to the MCP server or the Copilot CLI plugin.** The home page mentioned `hve-squad-mcp` in passing with a bare GitHub link, and `hve-squad-plugin` was absent from the site and the README entirely, so a consumer had no path from this repository to either sibling's documentation. Added an **Ecosystem** page (`docs/ecosystem.html`, wired into the navigation and pager across the site) covering what each of the three repositories is, which surface to use for which host, the MCP server's two execution modes and its tool set, the plugin's install-as-a-pair rule and its two update rules, and how releases stay aligned. The home page's companion section now covers both siblings with links to their GitHub Pages sites, and `README.md` gained a **Related repositories** table (`docs/index.html`, `README.md`).

--- a/README.md
+++ b/README.md
@@ -39,12 +39,30 @@ Full documentation lives on the project site:
 |-------------------------------------------------------------------------------|--------------------------------------------------------------------------|
 | [Getting Started](https://peter-n91.github.io/hve-squad/getting-started.html) | Prerequisites, installing the package with the correct target, first run |
 | [Usage](https://peter-n91.github.io/hve-squad/usage.html)                     | Profiles, autonomy modes, remote approval, and first-run Init Mode       |
+| [Ecosystem](https://peter-n91.github.io/hve-squad/ecosystem.html)             | The MCP server and the Copilot CLI plugin, and which surface to use      |
 | [Maintaining](https://peter-n91.github.io/hve-squad/maintaining.html)         | Dependency generation, author workflow, customization, release process   |
 | [Troubleshooting](https://peter-n91.github.io/hve-squad/troubleshooting.html) | Known install errors with fixes, versioning, and repository notes        |
 
 The site source is in [docs/](docs/) and is published to GitHub Pages by
 [.github/workflows/docs.yml](.github/workflows/docs.yml) on every push to `main` that touches
 `docs/`.
+
+## Related repositories
+
+This repository is the source of truth. The squad also ships through two sibling repositories,
+each generated from a tagged `hve-squad` release rather than maintained as a fork:
+
+- **[hve-squad-mcp](https://github.com/Peter-N91/hve-squad-mcp)** — an outbound MCP server that
+  publishes the squad as model-invocable tools, so hosts such as Copilot Studio can call it.
+  Docs: [peter-n91.github.io/hve-squad-mcp](https://peter-n91.github.io/hve-squad-mcp/)
+- **[hve-squad-plugin](https://github.com/Peter-N91/hve-squad-plugin)** — a generated,
+  release-gated mirror of the squad's GitHub Copilot CLI plugin tree, published as a plugin
+  marketplace. Docs: [peter-n91.github.io/hve-squad-plugin](https://peter-n91.github.io/hve-squad-plugin/)
+
+Use this package when you want `/squad` in VS Code Copilot Chat with the full cast installed in your
+repository, the plugin when you want the squad in the Copilot CLI or desktop app with no `apm install`,
+and the MCP server when another host should call the squad as tools. See
+[Ecosystem](https://peter-n91.github.io/hve-squad/ecosystem.html) for the full comparison.
 
 ## Quick start
 

--- a/docs/contributing.html
+++ b/docs/contributing.html
@@ -17,6 +17,7 @@
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
         <a href="demo.html">Demo</a>
+        <a href="ecosystem.html">Ecosystem</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="contributing.html" class="active">Contributing</a>

--- a/docs/demo-1.html
+++ b/docs/demo-1.html
@@ -17,6 +17,7 @@
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
         <a href="demo.html" class="active">Demo</a>
+        <a href="ecosystem.html">Ecosystem</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="contributing.html">Contributing</a>

--- a/docs/demo-2.html
+++ b/docs/demo-2.html
@@ -17,6 +17,7 @@
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
         <a href="demo.html" class="active">Demo</a>
+        <a href="ecosystem.html">Ecosystem</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="contributing.html">Contributing</a>

--- a/docs/demo-3.html
+++ b/docs/demo-3.html
@@ -17,6 +17,7 @@
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
         <a href="demo.html" class="active">Demo</a>
+        <a href="ecosystem.html">Ecosystem</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="contributing.html">Contributing</a>

--- a/docs/demo-4.html
+++ b/docs/demo-4.html
@@ -17,6 +17,7 @@
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
         <a href="demo.html" class="active">Demo</a>
+        <a href="ecosystem.html">Ecosystem</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="contributing.html">Contributing</a>
@@ -279,9 +280,9 @@
           <div class="dir">← Back</div>
           <div class="ttl">Demo 3 — Product Squad</div>
         </a>
-        <a class="next" href="maintaining.html">
+        <a class="next" href="ecosystem.html">
           <div class="dir">Next →</div>
-          <div class="ttl">Maintaining</div>
+          <div class="ttl">Ecosystem</div>
         </a>
       </div>
     </div>

--- a/docs/demo.html
+++ b/docs/demo.html
@@ -17,6 +17,7 @@
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
         <a href="demo.html" class="active">Demo</a>
+        <a href="ecosystem.html">Ecosystem</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="contributing.html">Contributing</a>

--- a/docs/ecosystem.html
+++ b/docs/ecosystem.html
@@ -1,0 +1,233 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Ecosystem — hve-squad</title>
+  <meta name="description" content="The three hve-squad repositories — the APM package, the MCP server, and the Copilot CLI plugin — what each one is for and where its documentation lives." />
+  <link rel="icon" type="image/svg+xml" href="assets/logo.svg" />
+  <link rel="stylesheet" href="assets/style.css" />
+</head>
+<body>
+  <nav class="nav">
+    <div class="nav-inner">
+      <a class="brand" href="index.html"><img src="assets/logo.svg" alt="" />hve<span class="dot">-</span>squad</a>
+      <div class="nav-links">
+        <a href="index.html">Home</a>
+        <a href="getting-started.html">Getting Started</a>
+        <a href="usage.html">Usage</a>
+        <a href="demo.html">Demo</a>
+        <a href="ecosystem.html" class="active">Ecosystem</a>
+        <a href="maintaining.html">Maintaining</a>
+        <a href="troubleshooting.html">Troubleshooting</a>
+        <a href="contributing.html">Contributing</a>
+        <a href="https://github.com/Peter-N91/hve-squad">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="hero">
+    <div class="container">
+      <div class="eyebrow">Reference</div>
+      <h1>Ecosystem</h1>
+      <p class="lead">
+        The squad ships through three repositories. This one is the source of truth; the other two
+        are distribution surfaces that carry the same cast to hosts an APM install cannot reach.
+      </p>
+    </div>
+  </header>
+
+  <main class="content">
+    <div class="container">
+      <h2>The three repositories</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>Repository</th>
+            <th>What it is</th>
+            <th>Documentation</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td><a href="https://github.com/Peter-N91/hve-squad"><code>hve-squad</code></a></td>
+            <td>This repository. The APM package and the authored squad source (<code>squad-src/</code>) that both other repositories are built from.</td>
+            <td><a href="index.html">peter-n91.github.io/hve-squad</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/Peter-N91/hve-squad-mcp"><code>hve-squad-mcp</code></a></td>
+            <td>An outbound Model Context Protocol server that publishes the squad as model-invocable tools, so MCP hosts can call it.</td>
+            <td><a href="https://peter-n91.github.io/hve-squad-mcp/">peter-n91.github.io/hve-squad-mcp</a></td>
+          </tr>
+          <tr>
+            <td><a href="https://github.com/Peter-N91/hve-squad-plugin"><code>hve-squad-plugin</code></a></td>
+            <td>A generated, release-gated mirror of the squad's GitHub Copilot CLI plugin tree, published as a plugin marketplace.</td>
+            <td><a href="https://peter-n91.github.io/hve-squad-plugin/">peter-n91.github.io/hve-squad-plugin</a></td>
+          </tr>
+        </tbody>
+      </table>
+
+      <div class="callout">
+        <p>
+          <strong>One cast, three doors.</strong> The roster, routing tables, and gates are authored
+          once here. The MCP server and the plugin do not fork that behavior &mdash; each is built
+          from a tagged <code>hve-squad</code> release, so a given version of any surface corresponds
+          to a known version of this package.
+        </p>
+      </div>
+
+      <h2>Which surface do I want?</h2>
+
+      <table>
+        <thead>
+          <tr>
+            <th>If you want to&hellip;</th>
+            <th>Use</th>
+            <th>Install</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr>
+            <td>Run <code>/squad</code> in VS Code Copilot Chat with the full cast in your repository</td>
+            <td>This APM package</td>
+            <td><code>apm install</code> &mdash; see <a href="getting-started.html">Getting Started</a></td>
+          </tr>
+          <tr>
+            <td>Run the squad from the GitHub Copilot CLI or the desktop app, with no APM install</td>
+            <td><code>hve-squad-plugin</code></td>
+            <td><code>copilot plugin marketplace add</code></td>
+          </tr>
+          <tr>
+            <td>Call the squad as tools from an MCP host such as Copilot Studio</td>
+            <td><code>hve-squad-mcp</code></td>
+            <td>stdio server locally, or a deployed HTTP endpoint</td>
+          </tr>
+        </tbody>
+      </table>
+
+      <h2>hve-squad-mcp — the MCP server</h2>
+
+      <p>
+        <a href="https://github.com/Peter-N91/hve-squad-mcp">github.com/Peter-N91/hve-squad-mcp</a>
+        &middot;
+        <a href="https://peter-n91.github.io/hve-squad-mcp/">docs site</a>
+      </p>
+
+      <p>
+        The server exposes coarse, model-invocable tools that map onto the squad's routing intents
+        rather than onto individual agents: <code>squad_research</code>, <code>squad_plan</code>,
+        <code>squad_review</code>, <code>squad_architect</code>, <code>squad_run</code>, and
+        <code>squad_federate</code>, plus a deterministic <code>squad_render_pptx</code> file-output
+        tool. Every tool's input mirrors the <code>/squad</code> prompt arguments.
+      </p>
+
+      <p>It runs in two modes, at different maturity levels:</p>
+
+      <ul>
+        <li>
+          <strong>Delegated (stdio)</strong> &mdash; VS Code dispatches the real deployed cast, so it
+          behaves as the full package. Requires the cast to be installed.
+        </li>
+        <li>
+          <strong>Embedded (remote Streamable HTTP + Entra)</strong> &mdash; reaches hosts such as
+          Copilot Studio, resolving personas server-side from the bundled cast under auth, gates,
+          tenant isolation, and cost caps. Scope is <em>advisory</em>: finished text deliverables, not
+          code-executing implement or deploy.
+        </li>
+      </ul>
+
+      <div class="callout warn">
+        <p>
+          <strong>Read the status table first.</strong> The server's README and docs site are explicit
+          about what works today versus what is a deferred execution expansion. Take claims about the
+          remote surface from there rather than from this page.
+        </p>
+      </div>
+
+      <p>
+        Useful entry points on its site:
+        <a href="https://peter-n91.github.io/hve-squad-mcp/getting-started.html">Getting Started</a>,
+        <a href="https://peter-n91.github.io/hve-squad-mcp/tools.html">Tools</a>,
+        <a href="https://peter-n91.github.io/hve-squad-mcp/configuration.html">Configuration</a>, and
+        <a href="https://peter-n91.github.io/hve-squad-mcp/deploy.html">Deploy</a>.
+      </p>
+
+      <h2>hve-squad-plugin — the Copilot CLI plugin</h2>
+
+      <p>
+        <a href="https://github.com/Peter-N91/hve-squad-plugin">github.com/Peter-N91/hve-squad-plugin</a>
+        &middot;
+        <a href="https://peter-n91.github.io/hve-squad-plugin/">docs site</a>
+      </p>
+
+      <p>
+        That repository is generated output, never hand-edited. Its <code>agents/</code>,
+        <code>skills/</code>, and <code>.github/plugin/plugin.json</code> are regenerated by
+        <a href="https://github.com/Peter-N91/hve-squad/blob/main/scripts/Build-SquadPlugin.ps1"><code>scripts/Build-SquadPlugin.ps1</code></a>
+        only when this repository cuts a release, extracted from that release's immutable git tag.
+        It exists so the distribution tree lives outside this working tree, mirroring the
+        <code>hve-squad-mcp</code> sibling-repo pattern.
+      </p>
+
+      <p>The marketplace publishes <strong>two entries, installed as a pair</strong>:</p>
+
+      <pre><code>copilot plugin marketplace add Peter-N91/hve-squad-plugin
+copilot plugin install hve-squad@hve-squad-plugin
+copilot plugin install hve-squad-hve-core@hve-squad-plugin</code></pre>
+
+      <div class="callout warn">
+        <p>
+          <strong>Two rules govern every later update.</strong> <code>hve-squad-hve-core</code> must be
+          uninstalled and reinstalled rather than updated &mdash; <code>copilot plugin update</code>
+          compares upstream hve-core's own version, so a moved pin reports <code>already at latest</code>
+          and the files never change. And do not <em>also</em> install the official <code>hve-core</code>
+          plugin next to it, or a dispatch can land on an unpinned second copy of every hve-core agent.
+          Both rules are explained in full on
+          <a href="https://peter-n91.github.io/hve-squad-plugin/install-cli.html">Install: Copilot CLI</a>.
+        </p>
+      </div>
+
+      <p>
+        Useful entry points on its site:
+        <a href="https://peter-n91.github.io/hve-squad-plugin/install-cli.html">Install: Copilot CLI</a>,
+        <a href="https://peter-n91.github.io/hve-squad-plugin/install-desktop.html">Install: Desktop app</a>,
+        <a href="https://peter-n91.github.io/hve-squad-plugin/install-vscode.html">Install: VS Code notes</a>,
+        <a href="https://peter-n91.github.io/hve-squad-plugin/architecture.html">Architecture</a>, and
+        <a href="https://peter-n91.github.io/hve-squad-plugin/enterprise-push.html">Enterprise Push</a>.
+      </p>
+
+      <h2>How releases stay aligned</h2>
+
+      <p>
+        Neither sibling repository is a fork. Both are produced from a tagged
+        <code>hve-squad</code> release, and each records the tag it was built from &mdash; the plugin
+        repository states its source tag and extraction date in its README, and each MCP release is
+        pinned to a matching package version. When this repository cuts a release, the downstream
+        surfaces are regenerated from it rather than drifting on their own schedule. See
+        <a href="maintaining.html">Maintaining</a> for the release process on this side.
+      </p>
+
+      <div class="pager">
+        <a class="prev" href="demo.html">
+          <div class="dir">← Back</div>
+          <div class="ttl">Demo</div>
+        </a>
+        <a class="next" href="maintaining.html">
+          <div class="dir">Next →</div>
+          <div class="ttl">Maintaining</div>
+        </a>
+      </div>
+    </div>
+  </main>
+
+  <footer class="footer">
+    <div class="container">
+      <p>
+        hve-squad · built on <a href="https://github.com/microsoft/hve-core">Microsoft HVE Core</a>
+        agents and conventions · <a href="https://github.com/Peter-N91/hve-squad">Source on GitHub</a>
+      </p>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -17,6 +17,7 @@
         <a href="getting-started.html" class="active">Getting Started</a>
         <a href="usage.html">Usage</a>
         <a href="demo.html">Demo</a>
+        <a href="ecosystem.html">Ecosystem</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="contributing.html">Contributing</a>

--- a/docs/index.html
+++ b/docs/index.html
@@ -17,6 +17,7 @@
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
         <a href="demo.html">Demo</a>
+        <a href="ecosystem.html">Ecosystem</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="contributing.html">Contributing</a>
@@ -66,8 +67,12 @@
             <h3>Demo</h3>
             <p>Two runnable walkthroughs — an Azure squad (cost, architecture, IaC, gated deploy, as-built, diagnose) and a non-technical product squad (discovery, requirements, roadmap, deck) — each with a say-it-once autopilot version.</p>
             <span class="tag">Walkthrough</span>
-          </a>
-          <a class="card" href="maintaining.html">
+          </a>          <a class="card" href="ecosystem.html">
+            <div class="icon">🌐</div>
+            <h3>Ecosystem</h3>
+            <p>The MCP server and the Copilot CLI plugin &mdash; what each surface is for, and where their repositories and documentation sites live.</p>
+            <span class="tag">Reference</span>
+          </a>          <a class="card" href="maintaining.html">
             <div class="icon">🔧</div>
             <h3>Maintaining</h3>
             <p>Dependency generation, the author workflow, customization, and the release process.</p>
@@ -141,17 +146,42 @@
 
     <section class="section">
       <div class="container">
-        <p class="section-label">Companion server</p>
+        <p class="section-label">Companion projects</p>
         <p>
-          Beyond the local <code>/squad</code> experience, the squad is also available as a deployable
-          <strong>Model Context Protocol (MCP) server</strong>. It publishes the squad as
-          model-invocable tools — <code>squad_research</code>, <code>squad_plan</code>,
-          <code>squad_review</code>, <code>squad_architect</code>, <code>squad_run</code>, and a
-          deterministic <code>squad_render_pptx</code> file-output tool — over Streamable HTTP with
-          Entra auth, so hosts such as Copilot Studio can call the squad. It ships in its own
-          repository and each release is pinned to a matching hve-squad package version.
+          Beyond the local <code>/squad</code> experience, the squad reaches two other hosts through
+          sibling repositories. Neither is a fork &mdash; both are built from a tagged
+          <code>hve-squad</code> release, so each version maps back to a known version of this package.
+          See <a href="ecosystem.html">Ecosystem</a> for how to choose between them.
         </p>
-        <a class="btn btn-ghost" href="https://github.com/Peter-N91/hve-squad-mcp">hve-squad-mcp on GitHub →</a>
+        <div class="grid">
+          <div class="card">
+            <div class="icon">🔌</div>
+            <h3>MCP server</h3>
+            <p>
+              <code>hve-squad-mcp</code> publishes the squad as model-invocable tools &mdash;
+              <code>squad_research</code>, <code>squad_plan</code>, <code>squad_review</code>,
+              <code>squad_architect</code>, <code>squad_run</code>, and a deterministic
+              <code>squad_render_pptx</code> file-output tool &mdash; over Streamable HTTP with Entra
+              auth, so hosts such as Copilot Studio can call the squad.
+            </p>
+            <span class="tag">MCP</span>
+          </div>
+          <div class="card">
+            <div class="icon">🧩</div>
+            <h3>Copilot CLI plugin</h3>
+            <p>
+              <code>hve-squad-plugin</code> is a generated, release-gated mirror of the squad's plugin
+              tree, published as a Copilot plugin marketplace. It runs the squad in the GitHub Copilot
+              CLI and the desktop app with no <code>apm install</code>.
+            </p>
+            <span class="tag">Plugin</span>
+          </div>
+        </div>
+        <p>
+          <a class="btn btn-ghost" href="ecosystem.html">Ecosystem overview →</a>
+          <a class="btn btn-ghost" href="https://peter-n91.github.io/hve-squad-mcp/">hve-squad-mcp docs →</a>
+          <a class="btn btn-ghost" href="https://peter-n91.github.io/hve-squad-plugin/">hve-squad-plugin docs →</a>
+        </p>
       </div>
     </section>
 

--- a/docs/maintaining.html
+++ b/docs/maintaining.html
@@ -17,6 +17,7 @@
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
         <a href="demo.html">Demo</a>
+        <a href="ecosystem.html">Ecosystem</a>
         <a href="maintaining.html" class="active">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="contributing.html">Contributing</a>
@@ -536,9 +537,9 @@ pwsh -File scripts/Invoke-ReleasePrep.ps1 -Version 1.0.0    # force an exact ver
       </p>
 
       <div class="pager">
-        <a class="prev" href="demo.html">
+        <a class="prev" href="ecosystem.html">
           <div class="dir">← Back</div>
-          <div class="ttl">Demo</div>
+          <div class="ttl">Ecosystem</div>
         </a>
         <a class="next" href="troubleshooting.html">
           <div class="dir">Next →</div>

--- a/docs/troubleshooting.html
+++ b/docs/troubleshooting.html
@@ -17,6 +17,7 @@
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html">Usage</a>
         <a href="demo.html">Demo</a>
+        <a href="ecosystem.html">Ecosystem</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html" class="active">Troubleshooting</a>
         <a href="contributing.html">Contributing</a>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -17,6 +17,7 @@
         <a href="getting-started.html">Getting Started</a>
         <a href="usage.html" class="active">Usage</a>
         <a href="demo.html">Demo</a>
+        <a href="ecosystem.html">Ecosystem</a>
         <a href="maintaining.html">Maintaining</a>
         <a href="troubleshooting.html">Troubleshooting</a>
         <a href="contributing.html">Contributing</a>


### PR DESCRIPTION
## Summary

Adds an **Ecosystem** page to the docs site and wires it into the navigation, so a consumer can get from this repository to `hve-squad-mcp` and `hve-squad-plugin` — their GitHub repos and their GitHub Pages sites. Previously the MCP server was a single passing mention with a bare GitHub link on the home page, and the plugin was absent from the site and the README entirely.

## Type of change

- [ ] Feature / new content
- [ ] Fix
- [x] Docs only
- [ ] Chore / maintenance

## Change fragment

- [x] Added a fragment under `.changes/unreleased/` (`apm run change`)
- [x] Its `bump` tracks ideas, not artifacts: `patch` unless this introduces a genuinely new idea (`minor`) or breaks consumers (`major`)
- [x] Its body reads as final release notes, not as a commit message
- [x] I did not edit `CHANGELOG.md` or `apm.yml` `version:`

## Tests

- [x] Added or extended an automated test case for the behavior this PR changes, or this PR changes no observable behavior
- [x] Declared the case in `tests/squad-behavior-contract.md` with an ID and a citation to the source file stating the rule
- [x] Ran `apm run test` (Tier 0) locally and it passed

Docs-only: no `squad-src/`, `apm.yml`, or test-surface change, so there is no observable squad behavior to assert and no Tier 0 gate on this path.

## Notes

What the new page covers:

- The three repositories, each with its GitHub repo and GitHub Pages link
- A "which surface do I want?" table (APM package vs. plugin vs. MCP server)
- `hve-squad-mcp`: the tool set, and the delegated (stdio) vs. embedded (remote) modes
- `hve-squad-plugin`: generated-mirror provenance, install-as-a-pair, and the two update rules
- How releases stay aligned across the three repositories

The MCP section deliberately points readers to that repository's own status table rather than restating maturity claims here — the remote surface is advisory-only and an execution expansion is deferred, so keeping the claims in one place stops this page drifting into overclaiming.

Also updated: the home page's "Companion server" section is now "Companion projects" covering both siblings with docs-site links, plus an Ecosystem card in the Start here grid; `README.md` gained an Ecosystem row in the docs table and a "Related repositories" section.

Pager chain is now demo-4 → Ecosystem → Maintaining. `markdownlint-cli2` on `README.md` is clean apart from the pre-existing MD013/MD033/MD041 hits in the badge block.
